### PR TITLE
Pygame viewer: persistent window + native keyboard input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,75 +3,93 @@
 ## Project Structure & Module Organization
 - Root-level Python tool: `video-wall.py` (main entrypoint).
 - Docs: `README.md`.
-- Dev environment: `shell.nix`, `.envrc` (direnv+nix; optional venv).
+- Dev environment: `shell.nix`, `.envrc` (direnv+nix).
 - No packages or tests folder yet; keep single-file CLI unless a refactor is discussed.
 
 ## Build, Test, and Development Commands
 - `direnv allow` — load nix shell and env (requires direnv).
-- `nix-shell` — enter dev shell with Python, ruff, and ffmpeg tools.
+- `nix-shell` — enter dev shell with Python, ruff, ffmpeg, and pygame.
 - `python3 video-wall.py <folder>` — run video wall.
-  - Example: `python3 video-wall.py ~/videos --count 9 --fast --hwaccel auto`.
+  - Example: `python3 video-wall.py ~/videos --count 9 --preset 3x3`.
 - `ruff check .` — lint Python code.
 
-Runtime dependencies: ensure `ffmpeg`, `ffprobe`, and `ffplay` are in `PATH`.
+Runtime dependencies: `ffmpeg`, `ffprobe` in `PATH`. `ffplay` needed only for audio.
 
 ## Current Feature Set (CLI)
-- Grid layout with `--count` 4–16; optional `--rows/--cols`.
+- Grid layout with `--count` 1–16; optional `--rows/--cols` or `--preset`.
 - Cell sizing via `--cell-width/--cell-height`; auto total size from grid.
-- Fast path `--fast` streaming rawvideo+pcm to `ffplay` (low latency/CPU).
+- Always rawvideo+pcm pipe to pygame viewer (no H.264 encode overhead).
+- `--border` adds black gaps between tiles.
+- `--fullscreen` / `-f` fullscreen mode.
 - Audio control: `--no-audio`, `--audio-mode {mix,one}`, `--audio-tile`, `--audio-rate`.
-- Hardware decode `--hwaccel {off,auto,cuda,vaapi}` with auto device discovery for VAAPI.
+  Audio played via separate headless ffplay (`-nodisp -vn`).
+- Hardware decode `--hwaccel {off,auto,cuda,vaapi}` with runtime CUDA lib check.
 - Input selection: recursive by default (`--no-recursive` to limit to top-level).
-- Supported extensions configurable via `--exts` (defaults to common video types).
-- Randomized start within `--start_percentage/--end_percentage` of duration.
+- Randomized start within `--start-pct/--end-pct` of duration.
 - Deterministic runs with `--seed`.
 - Verbose logging with `--verbose`.
 
 ## Runtime Keyboard Controls
+Keys work when the **pygame window** is focused (not the terminal).
+
 - SPACE: pause/resume pipeline.
 - r: replace a random tile.
 - 1..9: replace a specific tile (1-indexed).
-- f/F + number: seek forward 10s/30s for tile.
-- b/B + number: seek backward 10s/30s for tile.
+- a..f: replace tiles 10-15.
+- 0: replace the last tile (tile 16).
+- f/b: seek +10s/-10s, then press a tile number.
+- Shift+f/b: seek +30s/-30s.
 - q: quit.
 
-## Coding Style & Naming Conventions
-- Language: Python 3.10+ (uses `|` unions, dataclasses).
-- Indentation: 4 spaces; target line width ~100 chars.
-- Naming: `snake_case` for functions/vars, `PascalCase` for classes, `UPPER_CASE` for constants.
-- CLI: prefer explicit flags; keep current semantics backward compatible.
-- Linting: fix `ruff` findings or `# noqa` with a brief rationale.
+## Architecture
+Replaces the old ffplay-based pipeline with a **pygame viewer**:
+
+```
+ffmpeg (video) ──rawvideo pipe──▶ pygame viewer (SDL window, keyboard events)
+ffmpeg (audio)  ──wav pipe──────▶ ffplay -nodisp -vn (headless audio)
+```
+
+### VideoWindow
+- `VideoWindow` class owns the pygame window and ffmpeg subprocess lifecycle.
+- `select.select`-based non-blocking frame reads from ffmpeg stdout pipe.
+- `pygame.image.frombuffer()` converts raw RGB bytes to a display surface.
+- Keyboard events processed via `pygame.event.get()` — works when SDL window is focused.
+- On tile replace/seek: `_restart_ffmpeg()` kills the old ffmpeg, starts a new one.
+  **Pygame window stays open** — no flicker.
+- `AudioPipeline` helper manages a separate ffmpeg→ffplay chain for audio.
+
+### Models
+- `VideoMeta`, `HwAccelConfig`, `PipelineConfig`, `TileState` dataclasses.
+- `build_ffmpeg_cmd(cfg)` builds video ffmpeg argv, returns `(cmd, width, height)`.
+- `_build_audio_cmd(cfg)` builds simplified audio-only ffmpeg argv.
+- `_build_filter_graph()` generates the filter_complex string.
 
 ## Implementation Notes & Tips
-- Subprocess: never use `shell=True`; always pass argv lists (already implemented).
+- Subprocess: never use `shell=True`; always pass argv lists.
 - Metadata: `ffprobe` JSON is cached per-path in `_metadata_cache`.
 - Seeking: use `normalize_seek` and `random_seek` helpers; respect `--loop`.
 - Selection: `random.sample` is preferred to avoid mutation bias.
 - Tile replace: aim to pick unused, different videos first; fall back gracefully.
-- HW accel: `--hwaccel auto` prefers CUDA, then VAAPI if a writable render node is found.
-- VAAPI: auto-sets `-vaapi_device` when a suitable `/dev/dri/renderD*` is accessible.
-- Filters: performance can benefit from `--filter-threads` on multi-core systems.
+- HW accel: `--hwaccel auto` probes CUDA with runtime lib check, then VAAPI.
+- Display check: verifies `DISPLAY` or `WAYLAND_DISPLAY` is set before init.
+- Audio pipeline: started only when `--no-audio` is not set and at least one tile has audio.
 
 ## Testing Guidelines
-- Primary: manual runs against a local folder with supported extensions: `.mp4,.mov,.mkv,.avi,.m4v,.webm`.
+- Primary: manual runs against a local folder with supported extensions.
+- Requires a desktop session (X11/Wayland) — headless servers will error out cleanly.
 - Determinism: use `--seed <int>` for reproducible selection/seek behavior.
-- Smoke checks: `--fast --hwaccel auto --no-audio` on 4–9 files; verify tile replace/seek keys per on-screen help.
+- Smoke checks: `--hwaccel off --no-audio` on 4–9 files.
 - If adding logic, isolate pure helpers for future unit tests; keep side effects at the edges.
 
 ## Commit & Pull Request Guidelines
 - Commits: short, imperative mood ("Add …", "Fix …"), scoped changes.
-- PRs: include concise description, rationale, usage examples, and before/after behavior. Link issues as applicable and note HW/OS tested.
-- Screenshots or short screen recordings are helpful when UI/behavior changes.
+- PRs: include concise description, rationale, usage examples, and before/after behavior.
+- Screenshots or short screen recordings helpful when UI changes.
 
-## Security & Configuration Tips
-- Do not use `shell=True`; keep subprocess calls as argv lists.
-- Avoid changing default flags or hardware-accel behavior without discussion.
-- Validate file extensions and existence (already enforced); preserve these checks when modifying I/O.
-
-## Performance Tuning Cheat Sheet
-- Prefer `--fast` for low latency and CPU usage.
-- Set `--hwaccel auto` to enable CUDA/VAAPI when available.
-- Limit audio cost with `--audio-mode one` or `--no-audio`.
+## Performance Tuning
+- All modes use rawvideo pipe (no encode overhead).
+- Enable hardware decode with `--hwaccel auto`.
+- Reduce audio cost with `--audio-mode one` or `--no-audio`.
 - Lower audio rate (e.g., `--audio-rate 44100` or `32000`).
-- Adjust `--filter-threads 2` (or higher) on multi-core systems.
-- Reduce grid size or cell dimensions for constrained systems.
+- Reduce grid size or cell dimensions on constrained systems.
+- The pygame viewer uses `select.select` with 50ms timeout for non-blocking I/O.

--- a/README.md
+++ b/README.md
@@ -1,73 +1,107 @@
 # video-wall
 
-Single-window video wall that plays multiple videos in a grid, with low-latency fast mode and optional hardware-accelerated decode.
+Single-window video wall that plays multiple videos in a grid, using a **pygame** viewer with rawvideo pipe from ffmpeg.
 
 ## Features
-- Grid of N videos (`--count` 4–16) with optional `--rows`/`--cols`.
-- Per-cell sizing via `--cell-width`/`--cell-height` (total size is computed from grid).
-- Fast path (`--fast`) using rawvideo+pcm piped to `ffplay` for minimal latency and CPU.
+
+- Grid of N videos (`--count` 1–16) with `--rows`/`--cols` or `--preset` (e.g. `3x3`).
+- Per-cell sizing via `--cell-width`/`--cell-height`; total size computed from grid.
+- **Rawvideo pipe only** — no H.264 re-encode overhead.
+- **Pygame viewer** replaces ffplay — keyboard shortcuts work when the **video window is focused**, not the terminal.
+- **Window stays alive** on tile replacement/seeking — only ffmpeg restarts, no window flicker.
 - Audio options: `--no-audio`, `--audio-mode {mix,one}`, `--audio-tile`, `--audio-rate`.
-- Hardware decode: `--hwaccel {off,auto,cuda,vaapi}` with auto VAAPI device discovery.
-- Recursive file discovery by default; disable via `--no-recursive`.
-- Randomized starting offset within `--start_percentage/--end_percentage` of duration.
+  Audio is played through a separate headless ffplay (`-nodisp -vn`) fed from a second ffmpeg instance.
+- Hardware decode: `--hwaccel {auto,off,cuda,vaapi}` with runtime-CUDA detection.
+- Recursive file discovery by default; `--no-recursive` to restrict to one directory.
+- Randomized starting offset within `--start-pct`/`--end-pct` of duration.
 - Deterministic runs with `--seed`.
+- Grid presets: `--preset 3x3`, `4x4`, `2x3`, etc.
+- Tile border: `--border N` adds N-pixel black gap between tiles.
+- Fullscreen: `--fullscreen` / `-f`.
 
 ## Requirements
-- Runtime: `ffmpeg`, `ffprobe`, `ffplay` available in `PATH`.
-- Python 3.10+.
+
+- Runtime: `ffmpeg`, `ffprobe` in `PATH`. `ffplay` is only needed for audio (optional).
+- Python 3.10+ with **pygame** and **Pillow**.
+- A running desktop session (X11 or Wayland).
 
 Dev environment (optional):
+
 - `direnv allow` to load nix shell and env.
-- `nix-shell` to enter a dev shell with Python, ruff, and ffmpeg tools.
+- `nix-shell` to enter a dev shell with all dependencies.
 
 ## Usage
+
 ```
 python3 video-wall.py <folder> [options]
 ```
 
-Example:
-- Balanced preview: `python3 video-wall.py ~/videos --count 9 --fast --hwaccel auto`
-- Audio-light: `python3 video-wall.py ~/videos --count 6 --fast --audio-mode one --audio-rate 44100`
+Examples:
+
+- Basic: `python3 video-wall.py ~/videos --count 9`
+- With preset: `python3 video-wall.py ~/videos --preset 3x3`
+- Fullscreen: `python3 video-wall.py ~/videos --preset 3x3 --fullscreen --border 2`
 - Deterministic: `python3 video-wall.py ./clips --count 4 --seed 123`
 
-Key options:
-- `--count` N (4–16) — number of tiles.
-- `--rows/--cols` — override auto grid.
-- `--cell-width/--cell-height` — per-tile dimensions.
-- `--fast` — rawvideo+pcm for low latency and CPU.
-- `--no-audio` — disable audio entirely.
-- `--audio-mode mix|one` — mix all audio or use one tile only.
-- `--audio-tile` — 1-indexed tile to use when `--audio-mode one`.
-- `--audio-rate` — audio sample rate (e.g., 48000, 44100, 32000).
-- `--hwaccel off|auto|cuda|vaapi` — hardware decode mode (default off). Use `auto` to detect CUDA/VAAPI when possible.
-- `--exts` — comma-separated list of extensions to include (defaults to common video types).
-- `--recursive/--no-recursive` — include subdirectories (default recursive).
-- `--start_percentage/--end_percentage` — random start window as a fraction of duration.
-- `--seed` — reproducible selection and seeking.
-- `--verbose` — show ffmpeg/ffplay logs.
-- `--filter-threads` — threads for filter graph (advanced tuning).
+### Options reference
 
-Supported extensions (by default): `.mp4,.mov,.mkv,.avi,.m4v,.webm`.
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--count / -n` | 4 | Number of tiles (1–16) |
+| `--rows` | auto | Override number of rows |
+| `--cols` | auto | Override number of columns |
+| `--preset` | — | Grid preset: `2x2`, `3x2`, `2x3`, `3x3`, `4x3`, `3x4`, `4x4` |
+| `--cell-width` | 480 | Tile width in px |
+| `--cell-height` | 270 | Tile height in px |
+| `--border` | 0 | Black gap (px) between tiles |
+| `--volume` | 0.5 | Pre-mix gain per input |
+| `--loop` | off | Loop each input |
+| `--exts` | common types | Comma-separated extensions |
+| `--no-recursive` | off | Only top-level files (default: recursive) |
+| `--start-pct` | 0.5 | Start of random seek window (0–1) |
+| `--end-pct` | 0.75 | End of random seek window (0–1) |
+| `--seed` | — | Random seed for deterministic runs |
+| `--verbose / -v` | off | Show ffmpeg logs |
+| `--no-audio` | off | Disable audio |
+| `--audio-mode` | mix | `mix` all audio or `one` tile only |
+| `--audio-tile` | 0 | Tile index (0-based) for `--audio-mode=one` |
+| `--audio-rate` | 48000 | Audio sample rate in Hz |
+| `--fullscreen / -f` | off | Fullscreen mode |
+| `--hwaccel` | auto | `auto`, `off`, `cuda`, `vaapi` |
 
 ## Keyboard Controls
-- SPACE: pause/resume.
-- r: replace a random tile.
-- 1..9: replace a specific tile (1-indexed).
-- f/F + number: seek forward 10s/30s for the chosen tile.
-- b/B + number: seek backward 10s/30s for the chosen tile.
-- q: quit.
 
-## Performance Tips
-- Prefer `--fast` for lowest latency and CPU.
-- Enable hardware decode with `--hwaccel auto` when available (CUDA preferred, VAAPI supported).
-- Reduce audio cost via `--audio-mode one` or `--no-audio` when visuals are the focus.
-- Lower `--audio-rate` to `44100` or `32000` to save CPU.
-- Set `--filter-threads 2` (or higher) on multi-core systems.
-- Reduce `--count` or decrease `--cell-width/--cell-height` on constrained hardware.
+Keys work when the **pygame video window** is focused (not the terminal).
 
-## Notes on Hardware Acceleration
-- `--hwaccel auto` attempts CUDA first, then VAAPI if a writable `/dev/dri/renderD*` device is present; otherwise falls back to software.
-- VAAPI runs with auto `-vaapi_device` injection when the device is detected.
+| Key | Action |
+|-----|--------|
+| SPACE | pause/resume |
+| r | replace a random tile |
+| 1-9 | replace specific tile (1-indexed) |
+| a-f | replace tiles 10–15 (0 = last tile) |
+| f/b | seek forward/backward 10s, then press a tile |
+| Shift+f/b | seek forward/backward 30s |
+| q | quit |
+
+## Architecture
+
+```
+ffmpeg (video decode + filter graph) ──rawvideo pipe──▶ pygame viewer (display + keys)
+ffmpeg (audio mix only)              ──wav pipe──────▶ ffplay -nodisp -vn (headless audio)
+```
+
+- **Video pipeline**: Single ffmpeg decodes all input videos, builds an xstack filter graph, and outputs raw RGB24 frames via `image2pipe -` to stdout. The pygame viewer reads frames from the pipe using `select`-based non-blocking reads and displays them via `pygame.image.frombuffer`.
+- **Audio pipeline**: A second ffmpeg runs a simplified audio-only filter graph and outputs PCM/WAV to a second pipe, consumed by a headless ffplay (`-nodisp -vn`). Both pipelines share the same seek positions and are restarted together on tile changes.
+- **Window persistence**: On tile replace or seek, only ffmpeg subprocesses are killed and restarted. The pygame window stays open — no flicker.
+
+## Notes
+
+- Requires a display server (X11 or Wayland). Checked at startup via `DISPLAY`/`WAYLAND_DISPLAY` env vars.
+- The pygame AVX2 compile-time warning can be ignored (performance impact negligible).
+- Previous `--fast` flag removed — always uses rawvideo pipe (lowest latency).
 
 ## Linting
-Use `ruff check .` to lint the codebase.
+
+```bash
+ruff check .
+```

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,11 @@
-with import <nixpkgs> { };
+{ pkgs ? import <nixpkgs> { } }:
 
 pkgs.mkShell {
-  buildInputs = [
+  nativeBuildInputs = with pkgs; [
+    ffmpeg
     python3
+    python3Packages.pygame
+    python3Packages.pillow
     ruff
   ];
-
 }

--- a/video-wall.py
+++ b/video-wall.py
@@ -14,7 +14,6 @@ import shutil
 import signal
 import subprocess
 import sys
-import tempfile
 import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -303,7 +302,7 @@ def choose_hwaccel(pref: str | None = None) -> HwAccelConfig:
     return HwAccelConfig()
 
 
-# -------- ffmpeg command builder --------
+# -------- ffmpeg command builder (video only) --------
 
 
 def _build_filter_graph(
@@ -358,9 +357,6 @@ def _build_filter_graph(
         row = i // cfg.cols
         layout_parts.append(f"{col * stride_w}_{row * stride_h}")
 
-    # fps filter at the end of video chain: pace output to VIDEO_FPS.
-    # Without this, ffmpeg decodes faster than real-time and the
-    # pygame viewer displays frames at decode speed (sped-up video).
     layout = "|".join(layout_parts)
     flt.append(
         f"{''.join(vouts)}xstack=inputs={n}:layout={layout},"
@@ -370,16 +366,8 @@ def _build_filter_graph(
     return flt, vouts, with_audio
 
 
-def build_ffmpeg_cmd(
-    cfg: PipelineConfig, audio_fifo: str | None = None
-) -> tuple[list[str], int, int]:
-    """
-    Build ffmpeg command — single pipeline for video + audio.
-
-    Pacing is handled by pipe buffering + the pygame viewer's clock,
-    so we do NOT use -re (which can cause EOF issues on NFS mounts).
-    """
-    n = len(cfg.tiles)
+def build_video_cmd(cfg: PipelineConfig) -> tuple[list[str], int, int]:
+    """Build ffmpeg command that outputs raw RGB frames to stdout (video only)."""
     args = [
         "ffmpeg",
         "-hide_banner",
@@ -405,69 +393,60 @@ def build_ffmpeg_cmd(
             args += ["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"]
         elif wants_hw and cfg.hwaccel.mode == "vaapi":
             args += ["-hwaccel", "vaapi", "-hwaccel_output_format", "vaapi"]
-        # -ss BEFORE -i: fast seek (keyframe-based).
-        # Compatible with VAAPI/CUDA HW decoders. Sequential decode
-        # (-ss after -i) breaks with hardware acceleration.
         path_str = str(tile.path.absolute())
         args += ["-ss", f"{tile.seek:.3f}", "-i", path_str]
 
-    flt, vouts, with_audio = _build_filter_graph(cfg)
-
-    maps: list[str] = ["-map", "[V]"]
-    want_audio = not cfg.no_audio and bool(with_audio)
-    if want_audio:
-        if cfg.audio_mode == "one":
-            chosen = None
-            if cfg.audio_tile is not None and 0 <= cfg.audio_tile < n:
-                if cfg.audio_tile in with_audio:
-                    chosen = cfg.audio_tile
-            if chosen is None:
-                chosen = with_audio[0]
-            flt.append(f"[a{chosen}]aresample=async=1:min_hard_comp=0.100[A]")
-        else:
-            flt.append(
-                f"{''.join(f'[a{i}]' for i in with_audio)}"
-                f"amix=inputs={len(with_audio)}:dropout_transition=200[Apre]"
-            )
-            flt.append("[Apre]aresample=async=1:min_hard_comp=0.100[A]")
-        # [A] is NOT mapped globally; it's mapped only in the FIFO audio
-        # output section below, so it doesn't pollute the stdout pipe.
+    flt, vouts, _with_audio = _build_filter_graph(cfg)
+    # Video only — no audio mapping in this pipeline
+    maps = ["-map", "[V]"]
 
     total_w = cfg.cols * (cfg.cell_w + cfg.border) - cfg.border
     total_h = cfg.rows * (cfg.cell_h + cfg.border) - cfg.border
 
     args += ["-filter_complex", ";".join(flt), *maps, "-s", f"{total_w}x{total_h}"]
-
-    # ---- Video output to stdout ----
     args += [
-        "-c:v",
-        "rawvideo",
-        "-pix_fmt",
-        "rgb24",
-        "-r",
-        str(VIDEO_FPS),
-        "-f",
-        "image2pipe",
-        "-",
+        "-c:v", "rawvideo", "-pix_fmt", "rgb24",
+        "-r", str(VIDEO_FPS),
+        "-f", "image2pipe", "-",
     ]
-
-    # ---- Audio output to FIFO (only when needed) ----
-    # Use raw PCM (s16le) instead of WAV — WAV requires seeking to
-    # write the header, which fails on a named FIFO.
-    if want_audio and audio_fifo:
-        args += [
-            "-map",
-            "[A]",
-            "-c:a",
-            "pcm_s16le",
-            "-ar",
-            str(cfg.audio_rate),
-            "-f",
-            "s16le",
-            audio_fifo,
-        ]
-
     return args, total_w, total_h
+
+
+def build_audio_cmd(cfg: PipelineConfig) -> list[str] | None:
+    """Build a separate ffmpeg command for audio only, outputting PCM to stdout."""
+    with_audio = [i for i, t in enumerate(cfg.tiles) if t.metadata.has_audio]
+    if not with_audio:
+        return None
+
+    args = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "info" if cfg.verbose else "error",
+    ]
+    for t in cfg.tiles:
+        args += ["-ss", f"{t.seek:.3f}", "-i", str(t.path.absolute())]
+
+    flt_parts: list[str] = []
+    for i in with_audio:
+        flt_parts.append(f"[{i}:a]volume={cfg.volume}[a{i}]")
+
+    if cfg.audio_mode == "one":
+        chosen = with_audio[0] if cfg.audio_tile is None else cfg.audio_tile
+        if chosen not in with_audio:
+            chosen = with_audio[0]
+        flt_parts.append(f"[a{chosen}]aresample=async=1:min_hard_comp=0.100[A]")
+    else:
+        flt_parts.append(
+            f"{''.join(f'[a{i}]' for i in with_audio)}"
+            f"amix=inputs={len(with_audio)}:dropout_transition=200[Apre]"
+        )
+        flt_parts.append("[Apre]aresample=async=1:min_hard_comp=0.100[A]")
+
+    args += ["-filter_complex", ";".join(flt_parts)]
+    args += ["-map", "[A]", "-c:a", "pcm_s16le", "-ar", str(cfg.audio_rate)]
+    args += ["-f", "wav", "-"]
+    return args
 
 
 # -------- Kill helper --------
@@ -495,12 +474,13 @@ def kill_proc(p: subprocess.Popen | None) -> None:
 class VideoWindow:
     """Pygame window displaying raw RGB frames from an ffmpeg pipe.
 
-    A single ffmpeg instance decodes all tiles and outputs:
-      - raw RGB frames → stdout (read by this viewer)
-      - mixed audio WAV → FIFO (played by a headless ffplay)
+    Two independent ffmpeg instances:
+      - Video: ffmpeg → rawvideo pipe → pygame (reads & displays frames)
+      - Audio: ffmpeg → PCM pipe → ffplay -nodisp (headless playback)
 
-    The window stays open across tile replacements (only ffmpeg restarts).
-    Keyboard events from the pygame window (not terminal) control playback.
+    Each is restarted independently when tiles change.
+    The window stays open across restarts.
+    Keyboard events from the pygame window (not terminal).
     """
 
     def __init__(
@@ -526,10 +506,9 @@ class VideoWindow:
         self.running = False
         self.paused = False
 
-        self._ffmpeg: subprocess.Popen | None = None
-        self._ffplay_audio: subprocess.Popen | None = None
-        self._audio_fifo: str | None = None
-        self._audio_rate: int = 48000
+        self._ffmpeg_vid: subprocess.Popen | None = None
+        self._ffmpeg_aud: subprocess.Popen | None = None
+        self._ffplay_aud: subprocess.Popen | None = None
         self._pending_seek: float | None = None
         self._clock = pygame.time.Clock()
 
@@ -542,107 +521,73 @@ class VideoWindow:
         self._cfg_no_audio = False
         self._make_cfg = None
 
-    def _make_audio_fifo(self) -> str:
-        """Create a temporary FIFO for the audio pipeline."""
-        self._remove_audio_fifo()
-        fifo = os.path.join(tempfile.gettempdir(), f"videowall_audio_{os.getpid()}.wav")
-        try:
-            os.mkfifo(fifo)
-        except FileExistsError:
-            os.unlink(fifo)
-            os.mkfifo(fifo)
-        self._audio_fifo = fifo
-        return fifo
+    def _start_audio(self, cmd: list[str] | None) -> None:
+        """Start/replace the audio pipeline (ffmpeg → ffplay -nodisp)."""
+        kill_proc(self._ffmpeg_aud)
+        kill_proc(self._ffplay_aud)
+        self._ffmpeg_aud = None
+        self._ffplay_aud = None
 
-    def _remove_audio_fifo(self) -> None:
-        if self._audio_fifo and os.path.exists(self._audio_fifo):
-            try:
-                os.unlink(self._audio_fifo)
-            except OSError:
-                pass
-        self._audio_fifo = None
-
-    def _start_ffplay_audio(self) -> None:
-        """Start headless ffplay reading from the audio FIFO.
-
-        If ffplay is not available, audio is silently skipped.
-        """
-        self._stop_ffplay_audio()
-        if not self._audio_fifo or not os.path.exists(self._audio_fifo):
+        if not cmd:
             return
         if not shutil.which("ffplay"):
             if self.verbose:
                 print("[warn] ffplay not found — audio disabled", file=sys.stderr)
             return
-        self._ffplay_audio = subprocess.Popen(
+
+        self._ffplay_aud = subprocess.Popen(
             [
                 "ffplay",
-                "-nodisp",
-                "-vn",
-                "-loglevel",
-                "info" if self.verbose else "error",
+                "-nodisp", "-vn",
+                "-loglevel", "info" if self.verbose else "error",
                 "-autoexit",
-                "-f",
-                "s16le",
-                "-channels",
-                "2",
-                "-ar",
-                str(self._audio_rate),
-                "-i",
-                self._audio_fifo,
+                "-i", "pipe:0",
             ],
-            stdin=subprocess.DEVNULL,
+            stdin=subprocess.PIPE,
         )
+        self._ffmpeg_aud = subprocess.Popen(cmd, stdout=self._ffplay_aud.stdin)
 
-    def _stop_ffplay_audio(self) -> None:
-        kill_proc(self._ffplay_audio)
-        self._ffplay_audio = None
+    def _stop_audio(self) -> None:
+        kill_proc(self._ffmpeg_aud)
+        kill_proc(self._ffplay_aud)
+        self._ffmpeg_aud = None
+        self._ffplay_aud = None
 
-    def start_pipeline(self, cmd: list[str], want_audio: bool) -> None:
-        """Kill old ffmpeg, start new one, and (re)start audio ffplay.
-
-        The audio FIFO must already exist (created by _restart_pipeline).
-        IMPORTANT: ffplay is started BEFORE ffmpeg so the FIFO already
-        has a reader when ffmpeg opens it for writing — otherwise ffmpeg
-        hangs on open() waiting for a reader.
-        """
-        kill_proc(self._ffmpeg)
-        self._ffmpeg = None
-
-        if want_audio:
-            self._start_ffplay_audio()
-
-        # Stderr: show if verbose, hide otherwise
-        self._ffmpeg = subprocess.Popen(
+    def _start_video(self, cmd: list[str]) -> None:
+        """Start/replace the video ffmpeg pipeline."""
+        kill_proc(self._ffmpeg_vid)
+        self._ffmpeg_vid = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
             stderr=None if self.verbose else subprocess.DEVNULL,
         )
 
+    def _stop_video(self) -> None:
+        kill_proc(self._ffmpeg_vid)
+        self._ffmpeg_vid = None
+
     def _stop_procs(self) -> None:
-        kill_proc(self._ffmpeg)
-        self._ffmpeg = None
-        self._stop_ffplay_audio()
-        self._remove_audio_fifo()
+        self._stop_video()
+        self._stop_audio()
 
     def _read_frame(self) -> bytes | None:
-        """Read one raw RGB frame from the pipe.
+        """Read one raw RGB frame from the video pipe.
 
-        Uses select with a 50 ms timeout so we don't block event processing.
+        Uses select with a 10ms timeout so we don't block event processing.
         Returns None if the pipe is dead, b"" if no data ready yet.
         """
-        if self._ffmpeg is None or self._ffmpeg.stdout is None:
+        if self._ffmpeg_vid is None or self._ffmpeg_vid.stdout is None:
             return None
 
-        if self._ffmpeg.poll() is not None:
+        if self._ffmpeg_vid.poll() is not None:
             return None
 
-        fd = self._ffmpeg.stdout.fileno()
+        fd = self._ffmpeg_vid.stdout.fileno()
         r, _, _ = select.select([fd], [], [], 0.01)
         if not r:
             return b""  # no data yet, not an error
 
-        raw = self._ffmpeg.stdout.read(self.frame_size)
+        raw = self._ffmpeg_vid.stdout.read(self.frame_size)
         if len(raw) != self.frame_size:
             return None
         return raw
@@ -683,32 +628,27 @@ class VideoWindow:
         if pygame.K_1 <= key <= pygame.K_9:
             return key - pygame.K_1
         if key == pygame.K_0:
-            return MAX_TILES - 1  # last tile
+            return MAX_TILES - 1
         if pygame.K_a <= key <= pygame.K_f:
             return key - pygame.K_a + 9
         return None
 
     def _toggle_pause(self) -> None:
-        """Pause/resume via SIGSTOP/SIGCONT on the ffmpeg process."""
         if not self.paused:
-            try:
-                os.kill(self._ffmpeg.pid, signal.SIGSTOP)
-            except Exception:
-                pass
-            try:
-                os.kill(self._ffplay_audio.pid, signal.SIGSTOP)
-            except Exception:
-                pass
+            for p in (self._ffmpeg_vid, self._ffmpeg_aud, self._ffplay_aud):
+                if p is not None:
+                    try:
+                        os.kill(p.pid, signal.SIGSTOP)
+                    except Exception:
+                        pass
             self.paused = True
         else:
-            try:
-                os.kill(self._ffmpeg.pid, signal.SIGCONT)
-            except Exception:
-                pass
-            try:
-                os.kill(self._ffplay_audio.pid, signal.SIGCONT)
-            except Exception:
-                pass
+            for p in (self._ffmpeg_vid, self._ffmpeg_aud, self._ffplay_aud):
+                if p is not None:
+                    try:
+                        os.kill(p.pid, signal.SIGCONT)
+                    except Exception:
+                        pass
             self.paused = False
 
     def _replace_tile(self, index: int, restart: bool = True) -> None:
@@ -765,50 +705,32 @@ class VideoWindow:
         self._restart_pipeline()
 
     def _restart_pipeline(self) -> None:
-        """Kill ffmpeg/ffplay and start a unified single-ffmpeg pipeline.
-
-        The pygame window stays open — only the decode pipeline restarts.
-        The audio FIFO is created first so build_ffmpeg_cmd can reference it.
-        """
+        """Kill all processes and restart video + audio pipelines."""
         if self._make_cfg is None:
             return
 
-        # Pre-validate: ensure tile files are readable before starting ffmpeg
-        # (NFS workaround — catch stale handles / symlink issues early)
-        for i, tile in enumerate(self._tiles):
-            try:
-                with open(tile.path.absolute(), "rb") as fh:
-                    fh.read(1024)
-            except OSError as exc:
-                if self.verbose:
-                    print(
-                        f"[warn] tile {i} ({tile.path.name}) unreadable: "
-                        f"{exc} — picking replacement",
-                        file=sys.stderr,
-                    )
-                self._replace_tile(i, restart=False)
-
         cfg = self._make_cfg(self._tiles)
-        self._audio_rate = cfg.audio_rate
         want_audio = not cfg.no_audio
 
-        # Create/recreate the audio FIFO before building the command
-        if want_audio:
-            self._make_audio_fifo()
-        else:
-            self._stop_ffplay_audio()
-            self._remove_audio_fifo()
+        # Build commands
+        vid_cmd, w, h = build_video_cmd(cfg)
+        aud_cmd = build_audio_cmd(cfg) if want_audio else None
 
-        vid_cmd, w, h = build_ffmpeg_cmd(
-            cfg, audio_fifo=(self._audio_fifo if want_audio else None)
-        )
         if (w, h) != (self.width, self.height):
             self.width = w
             self.height = h
             self.frame_size = w * h * 3
             flags = self.screen.get_flags()
             self.screen = pygame.display.set_mode((w, h), flags)
-        self.start_pipeline(vid_cmd, want_audio)
+
+        # Stop old, start new — video first, then audio
+        kill_proc(self._ffmpeg_vid)
+        self._ffmpeg_vid = subprocess.Popen(
+            vid_cmd,
+            stdout=subprocess.PIPE,
+            stderr=None if self.verbose else subprocess.DEVNULL,
+        )
+        self._start_audio(aud_cmd)
 
     def run(
         self,
@@ -828,7 +750,6 @@ class VideoWindow:
         self._make_cfg = make_cfg
         self.running = True
 
-        # Initial pipeline start (creates FIFO + starts ffmpeg + ffplay)
         self._restart_pipeline()
 
         print(
@@ -855,8 +776,8 @@ class VideoWindow:
                 if not self.running:
                     break
 
-                # ---- Check if ffmpeg died unexpectedly ----
-                if self._ffmpeg is not None and self._ffmpeg.poll() is not None:
+                # ---- Check if video ffmpeg died unexpectedly ----
+                if self._ffmpeg_vid is not None and self._ffmpeg_vid.poll() is not None:
                     if not self.paused:
                         try:
                             self._replace_tile(random.randrange(len(self._tiles)))
@@ -869,7 +790,7 @@ class VideoWindow:
                 frame_data = self._read_frame()
 
                 if frame_data is None:
-                    if not self.paused and self._ffmpeg is not None:
+                    if not self.paused and self._ffmpeg_vid is not None:
                         self._restart_pipeline()
                     continue
 

--- a/video-wall.py
+++ b/video-wall.py
@@ -417,14 +417,14 @@ def build_ffmpeg_cmd(
             if chosen is None:
                 chosen = with_audio[0]
             flt.append(f"[a{chosen}]aresample=async=1:min_hard_comp=0.100[A]")
-            maps += ["-map", "[A]"]
         else:
             flt.append(
                 f"{''.join(f'[a{i}]' for i in with_audio)}"
                 f"amix=inputs={len(with_audio)}:dropout_transition=200[Apre]"
             )
             flt.append("[Apre]aresample=async=1:min_hard_comp=0.100[A]")
-            maps += ["-map", "[A]"]
+        # [A] is NOT mapped globally; it's mapped only in the FIFO audio
+        # output section below, so it doesn't pollute the stdout pipe.
 
     total_w = cfg.cols * (cfg.cell_w + cfg.border) - cfg.border
     total_h = cfg.rows * (cfg.cell_h + cfg.border) - cfg.border

--- a/video-wall.py
+++ b/video-wall.py
@@ -14,6 +14,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -22,7 +23,7 @@ from pathlib import Path
 os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
 warnings.filterwarnings("ignore", message=".*avx2.*", category=RuntimeWarning)
 
-import pygame  # noqa: E402 — intentional late import after env/warnings setup
+import pygame  # noqa: E402 — intentional late import
 
 DEFAULT_EXTS = (".mp4", ".mov", ".mkv", ".avi", ".m4v", ".webm")
 GRID_PRESETS = {
@@ -36,6 +37,7 @@ GRID_PRESETS = {
 }
 MAX_TILES = 16
 TITLE = "Video Wall"
+VIDEO_FPS = 30
 
 
 # -------- Models --------
@@ -362,10 +364,15 @@ def _build_filter_graph(
     return flt, vouts, with_audio
 
 
-def build_ffmpeg_cmd(cfg: PipelineConfig) -> tuple[list[str], int, int]:
-    """Build ffmpeg command that outputs raw RGB frames to stdout.
+def build_ffmpeg_cmd(
+    cfg: PipelineConfig, audio_fifo: str | None = None
+) -> tuple[list[str], int, int]:
+    """
+    Build ffmpeg command — single pipeline for video + audio.
 
-    Returns (cmd_list, total_width, total_height).
+    - Reads inputs at real-time speed (-re) to pace frame output.
+    - Outputs raw RGB frames to stdout for the pygame viewer.
+    - If audio_fifo is set, also outputs mixed audio as WAV to that FIFO.
     """
     n = len(cfg.tiles)
     args = [
@@ -389,6 +396,8 @@ def build_ffmpeg_cmd(cfg: PipelineConfig) -> tuple[list[str], int, int]:
 
         if cfg.loop:
             args += ["-stream_loop", "-1"]
+        # -re: read input at native framerate → real-time decode → correct pace
+        args += ["-re"]
         if wants_hw and cfg.hwaccel.mode == "cuda":
             args += ["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"]
         elif wants_hw and cfg.hwaccel.mode == "vaapi":
@@ -422,8 +431,33 @@ def build_ffmpeg_cmd(cfg: PipelineConfig) -> tuple[list[str], int, int]:
 
     args += ["-filter_complex", ";".join(flt), *maps, "-s", f"{total_w}x{total_h}"]
 
-    # Output raw RGB for our pygame viewer (no YUV→RGB conversion in Python)
-    args += ["-c:v", "rawvideo", "-pix_fmt", "rgb24", "-f", "image2pipe", "-"]
+    # ---- Video output to stdout ----
+    args += [
+        "-c:v",
+        "rawvideo",
+        "-pix_fmt",
+        "rgb24",
+        "-r",
+        str(VIDEO_FPS),
+        "-f",
+        "image2pipe",
+        "-",
+    ]
+
+    # ---- Audio output to FIFO (only when needed) ----
+    if want_audio and audio_fifo:
+        args += [
+            "-map",
+            "[A]",
+            "-c:a",
+            "pcm_s16le",
+            "-ar",
+            str(cfg.audio_rate),
+            "-f",
+            "wav",
+            audio_fifo,
+        ]
+
     return args, total_w, total_h
 
 
@@ -446,109 +480,18 @@ def kill_proc(p: subprocess.Popen | None) -> None:
             pass
 
 
-# -------- Audio pipeline --------
-
-
-def _build_audio_cmd(cfg: PipelineConfig) -> list[str] | None:
-    """Simplified ffmpeg command: audio mix only → stdout PCM."""
-    with_audio = [i for i, t in enumerate(cfg.tiles) if t.metadata.has_audio]
-    if not with_audio:
-        return None
-
-    args = [
-        "ffmpeg",
-        "-hide_banner",
-        "-loglevel",
-        "info" if cfg.verbose else "error",
-    ]
-    for t in cfg.tiles:
-        args += ["-ss", f"{t.seek:.3f}", "-i", str(t.path)]
-
-    flt_parts: list[str] = []
-    for i in with_audio:
-        flt_parts.append(f"[{i}:a]volume={cfg.volume}[a{i}]")
-
-    if cfg.audio_mode == "one":
-        chosen = with_audio[0] if cfg.audio_tile is None else cfg.audio_tile
-        if chosen not in with_audio:
-            chosen = with_audio[0]
-        flt_parts.append(f"[a{chosen}]aresample=async=1:min_hard_comp=0.100[A]")
-    else:
-        flt_parts.append(
-            f"{''.join(f'[a{i}]' for i in with_audio)}"
-            f"amix=inputs={len(with_audio)}:dropout_transition=200[Apre]"
-        )
-        flt_parts.append("[Apre]aresample=async=1:min_hard_comp=0.100[A]")
-
-    args += ["-filter_complex", ";".join(flt_parts)]
-    args += ["-map", "[A]", "-c:a", "pcm_s16le", "-ar", str(cfg.audio_rate)]
-    args += ["-f", "wav", "-"]
-    return args
-
-
-class AudioPipeline:
-    """Separate ffmpeg → ffplay audio playback (no visual window)."""
-
-    def __init__(self, verbose: bool = False):
-        self.ffmpeg: subprocess.Popen | None = None
-        self.ffplay: subprocess.Popen | None = None
-        self.verbose = verbose
-
-    @property
-    def running(self) -> bool:
-        return self.ffplay is not None and self.ffplay.poll() is None
-
-    def start(self, cmd: list[str]) -> None:
-        self.stop()
-        if not cmd:
-            return
-        self.ffplay = subprocess.Popen(
-            [
-                "ffplay",
-                "-nodisp",
-                "-vn",
-                "-loglevel",
-                "info" if self.verbose else "error",
-                "-autoexit",
-                "-i",
-                "pipe:0",
-            ],
-            stdin=subprocess.PIPE,
-        )
-        self.ffmpeg = subprocess.Popen(cmd, stdout=self.ffplay.stdin)
-
-    def stop(self) -> None:
-        kill_proc(self.ffmpeg)
-        kill_proc(self.ffplay)
-        self.ffmpeg = None
-        self.ffplay = None
-
-    def pause(self) -> None:
-        for p in (self.ffmpeg, self.ffplay):
-            if p is not None:
-                try:
-                    os.kill(p.pid, signal.SIGSTOP)
-                except Exception:
-                    pass
-
-    def resume(self) -> None:
-        for p in (self.ffmpeg, self.ffplay):
-            if p is not None:
-                try:
-                    os.kill(p.pid, signal.SIGCONT)
-                except Exception:
-                    pass
-
-
 # -------- Pygame viewer --------
 
 
 class VideoWindow:
     """Pygame window displaying raw RGB frames from an ffmpeg pipe.
 
-    The window stays open between tile replacements (only ffmpeg restarts).
-    Keyboard events are handled by the pygame event loop, so they
-    work when the pygame window is focused (not the terminal).
+    A single ffmpeg instance decodes all tiles and outputs:
+      - raw RGB frames → stdout (read by this viewer)
+      - mixed audio WAV → FIFO (played by a headless ffplay)
+
+    The window stays open across tile replacements (only ffmpeg restarts).
+    Keyboard events from the pygame window (not terminal) control playback.
     """
 
     def __init__(
@@ -561,7 +504,7 @@ class VideoWindow:
         pygame.display.init()
         pygame.key.set_repeat(300, 80)
 
-        flags = pygame.FULLSCREEN if fullscreen else 0
+        flags = pygame.FULLSCREEN | pygame.SCALED if fullscreen else 0
         self.screen = pygame.display.set_mode((width, height), flags)
         pygame.display.set_caption(TITLE)
         if fullscreen:
@@ -575,7 +518,8 @@ class VideoWindow:
         self.paused = False
 
         self._ffmpeg: subprocess.Popen | None = None
-        self._audio = AudioPipeline(verbose=verbose)
+        self._ffplay_audio: subprocess.Popen | None = None
+        self._audio_fifo: str | None = None
         self._pending_seek: float | None = None
         self._clock = pygame.time.Clock()
 
@@ -585,31 +529,81 @@ class VideoWindow:
         self._start_pct = 0.5
         self._end_pct = 0.75
         self._loop = False
+        self._cfg_no_audio = False
         self._make_cfg = None
 
-    def start_video(self, cmd: list[str]) -> None:
+    def _make_audio_fifo(self) -> str:
+        """Create a temporary FIFO for the audio pipeline."""
+        self._remove_audio_fifo()
+        fifo = os.path.join(tempfile.gettempdir(), f"videowall_audio_{os.getpid()}.wav")
+        try:
+            os.mkfifo(fifo)
+        except FileExistsError:
+            os.unlink(fifo)
+            os.mkfifo(fifo)
+        self._audio_fifo = fifo
+        return fifo
+
+    def _remove_audio_fifo(self) -> None:
+        if self._audio_fifo and os.path.exists(self._audio_fifo):
+            try:
+                os.unlink(self._audio_fifo)
+            except OSError:
+                pass
+        self._audio_fifo = None
+
+    def _start_ffplay_audio(self) -> None:
+        """Start headless ffplay reading from the audio FIFO."""
+        self._stop_ffplay_audio()
+        if not self._audio_fifo or not os.path.exists(self._audio_fifo):
+            return
+        self._ffplay_audio = subprocess.Popen(
+            [
+                "ffplay",
+                "-nodisp",
+                "-vn",
+                "-loglevel",
+                "info" if self.verbose else "error",
+                "-autoexit",
+                "-i",
+                self._audio_fifo,
+            ],
+            stdin=subprocess.DEVNULL,
+        )
+
+    def _stop_ffplay_audio(self) -> None:
+        kill_proc(self._ffplay_audio)
+        self._ffplay_audio = None
+
+    def start_pipeline(self, cmd: list[str], want_audio: bool) -> None:
+        """Kill old ffmpeg, start new one, and (re)start audio ffplay.
+
+        The audio FIFO must already exist (created by _restart_pipeline).
+        """
         kill_proc(self._ffmpeg)
+        self._ffmpeg = None
+
+        # Stderr: show if verbose, hide otherwise
         self._ffmpeg = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL if not self.verbose else None,
+            stderr=None if self.verbose else subprocess.DEVNULL,
         )
 
-    def start_audio(self, cmd: list[str] | None) -> None:
-        self._audio.stop()
-        if cmd:
-            self._audio.start(cmd)
+        if want_audio:
+            self._start_ffplay_audio()
 
     def _stop_procs(self) -> None:
         kill_proc(self._ffmpeg)
         self._ffmpeg = None
-        self._audio.stop()
+        self._stop_ffplay_audio()
+        self._remove_audio_fifo()
 
     def _read_frame(self) -> bytes | None:
         """Read one raw RGB frame from the pipe.
 
         Uses select with a 50 ms timeout so we don't block event processing.
-        Returns None if the pipe is dead or has no data ready.
+        Returns None if the pipe is dead, b"" if no data ready yet.
         """
         if self._ffmpeg is None or self._ffmpeg.stdout is None:
             return None
@@ -628,7 +622,7 @@ class VideoWindow:
         return raw
 
     def _handle_key(self, key: int, mod: int):
-        """Process a pygame KEYDOWN event. Dispatches to tile actions."""
+        """Process a pygame KEYDOWN event."""
         if key == pygame.K_q:
             self.running = False
             return
@@ -669,19 +663,26 @@ class VideoWindow:
         return None
 
     def _toggle_pause(self) -> None:
+        """Pause/resume via SIGSTOP/SIGCONT on the ffmpeg process."""
         if not self.paused:
             try:
                 os.kill(self._ffmpeg.pid, signal.SIGSTOP)
             except Exception:
                 pass
-            self._audio.pause()
+            try:
+                os.kill(self._ffplay_audio.pid, signal.SIGSTOP)
+            except Exception:
+                pass
             self.paused = True
         else:
             try:
                 os.kill(self._ffmpeg.pid, signal.SIGCONT)
             except Exception:
                 pass
-            self._audio.resume()
+            try:
+                os.kill(self._ffplay_audio.pid, signal.SIGCONT)
+            except Exception:
+                pass
             self.paused = False
 
     def _replace_tile(self, index: int) -> None:
@@ -727,34 +728,43 @@ class VideoWindow:
             path=new_path,
             seek=random_seek(new_path, self._loop, self._start_pct, self._end_pct),
         )
-        self._restart_ffmpeg()
+        self._restart_pipeline()
 
     def _seek_tile(self, index: int, delta: float) -> None:
         if not (0 <= index < len(self._tiles)):
             return
         t = self._tiles[index]
         t.seek = normalize_seek(t.path, t.seek + delta, self._loop)
-        self._restart_ffmpeg()
+        self._restart_pipeline()
 
-    def _restart_ffmpeg(self) -> None:
-        """Kill the current ffmpeg and start a new one with current tile state.
+    def _restart_pipeline(self) -> None:
+        """Kill ffmpeg/ffplay and start a unified single-ffmpeg pipeline.
 
         The pygame window stays open — only the decode pipeline restarts.
+        The audio FIFO is created first so build_ffmpeg_cmd can reference it.
         """
         if self._make_cfg is None:
             return
         cfg = self._make_cfg(self._tiles)
-        vid_cmd, w, h = build_ffmpeg_cmd(cfg)
+        want_audio = not cfg.no_audio
+
+        # Create/recreate the audio FIFO before building the command
+        if want_audio:
+            self._make_audio_fifo()
+        else:
+            self._stop_ffplay_audio()
+            self._remove_audio_fifo()
+
+        vid_cmd, w, h = build_ffmpeg_cmd(
+            cfg, audio_fifo=(self._audio_fifo if want_audio else None)
+        )
         if (w, h) != (self.width, self.height):
             self.width = w
             self.height = h
             self.frame_size = w * h * 3
-            self.screen = pygame.display.set_mode((w, h), self.screen.get_flags())
-        self.start_video(vid_cmd)
-        if not cfg.no_audio:
-            self.start_audio(_build_audio_cmd(cfg))
-        else:
-            self._audio.stop()
+            flags = self.screen.get_flags()
+            self.screen = pygame.display.set_mode((w, h), flags)
+        self.start_pipeline(vid_cmd, want_audio)
 
     def run(
         self,
@@ -765,11 +775,7 @@ class VideoWindow:
         loop: bool,
         make_cfg,
     ) -> None:
-        """Main loop: read frames, display, handle pygame events.
-
-        make_cfg(tiles) returns a PipelineConfig for current tile state.
-        Called to rebuild the ffmpeg command after tile mutations.
-        """
+        """Main loop: read frames, display, handle pygame events."""
         self._tiles = tiles
         self._pool = pool
         self._start_pct = start_pct
@@ -778,8 +784,8 @@ class VideoWindow:
         self._make_cfg = make_cfg
         self.running = True
 
-        # Initial pipeline start
-        self._restart_ffmpeg()
+        # Initial pipeline start (creates FIFO + starts ffmpeg + ffplay)
+        self._restart_pipeline()
 
         print(
             "Controls:\n"
@@ -791,8 +797,6 @@ class VideoWindow:
             "  q         = quit\n",
             file=sys.stderr,
         )
-
-        surface: pygame.Surface | None = None
 
         try:
             while self.running:
@@ -809,32 +813,35 @@ class VideoWindow:
 
                 # ---- Check if ffmpeg died unexpectedly ----
                 if self._ffmpeg is not None and self._ffmpeg.poll() is not None:
-                    # Swap a random tile if it crashed within 1s
                     if not self.paused:
                         try:
                             self._replace_tile(random.randrange(len(self._tiles)))
                             continue
                         except Exception:
                             pass
-                    self._restart_ffmpeg()
+                    self._restart_pipeline()
 
                 # ---- Read and display frame ----
                 frame_data = self._read_frame()
 
                 if frame_data is None:
-                    # Pipe is dead — restart
                     if not self.paused and self._ffmpeg is not None:
-                        self._restart_ffmpeg()
+                        self._restart_pipeline()
                     continue
 
                 if frame_data == b"":
-                    # No frame ready yet — keep the last frame visible, carry on
                     self._clock.tick(60)
                     continue
 
                 surface = pygame.image.frombuffer(
                     frame_data, (self.width, self.height), "RGB"
                 )
+
+                # In fullscreen mode, scale the surface to fill the screen
+                win_w, win_h = self.screen.get_size()
+                if win_w != self.width or win_h != self.height:
+                    surface = pygame.transform.scale(surface, (win_w, win_h))
+
                 self.screen.blit(surface, (0, 0))
                 pygame.display.flip()
 
@@ -851,6 +858,7 @@ class VideoWindow:
 def main() -> None:
     need("ffmpeg")
     need("ffprobe")
+    need("ffplay")
 
     ap = argparse.ArgumentParser(
         description="Single-window video wall with pygame viewer.",

--- a/video-wall.py
+++ b/video-wall.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""video-wall — Single-window video wall with pygame viewer."""
+"""video-wall — Single-window video wall with pygame viewer (video only)."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ from pathlib import Path
 os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
 warnings.filterwarnings("ignore", message=".*avx2.*", category=RuntimeWarning)
 
-import pygame  # noqa: E402 — intentional late import
+import pygame  # noqa: E402 — intentional late import after env setup
 
 DEFAULT_EXTS = (".mp4", ".mov", ".mkv", ".avi", ".m4v", ".webm")
 GRID_PRESETS = {
@@ -68,13 +68,8 @@ class PipelineConfig:
     cell_w: int
     cell_h: int
     loop: bool
-    volume: float
     hwaccel: HwAccelConfig
     verbose: bool
-    no_audio: bool
-    audio_mode: str
-    audio_tile: int | None
-    audio_rate: int
     border: int
     fullscreen: bool
 
@@ -302,22 +297,20 @@ def choose_hwaccel(pref: str | None = None) -> HwAccelConfig:
     return HwAccelConfig()
 
 
-# -------- ffmpeg command builder (video only) --------
+# -------- ffmpeg command builder --------
 
 
 def _build_filter_graph(
-    cfg: PipelineConfig, include_audio: bool = True
-) -> tuple[list[str], list[str], list[int]]:
-    n = len(cfg.tiles)
+    cfg: PipelineConfig,
+) -> tuple[list[str], list[str]]:
+    """Build filter graph for the video xstack wall. Video only — no audio."""
     flt: list[str] = []
     vouts: list[str] = []
-    with_audio: list[int] = []
 
     stride_w = cfg.cell_w + cfg.border
     stride_h = cfg.cell_h + cfg.border
 
     for i, tile in enumerate(cfg.tiles):
-        meta = tile.metadata
         ops: list[str] = []
 
         hw = cfg.hwaccel.mode
@@ -347,27 +340,23 @@ def _build_filter_graph(
         vouts.append(f"[v{i}]")
         flt.append(f"[{i}:v]{','.join(ops)}[v{i}]")
 
-        if include_audio and not cfg.no_audio and meta.has_audio:
-            with_audio.append(i)
-            flt.append(f"[{i}:a]volume={cfg.volume}[a{i}]")
-
     layout_parts: list[str] = []
-    for i in range(n):
+    for i in range(len(cfg.tiles)):
         col = i % cfg.cols
         row = i // cfg.cols
         layout_parts.append(f"{col * stride_w}_{row * stride_h}")
 
     layout = "|".join(layout_parts)
     flt.append(
-        f"{''.join(vouts)}xstack=inputs={n}:layout={layout},"
+        f"{''.join(vouts)}xstack=inputs={len(cfg.tiles)}:layout={layout},"
         f"fps={VIDEO_FPS}[V]"
     )
 
-    return flt, vouts, with_audio
+    return flt, vouts
 
 
 def build_video_cmd(cfg: PipelineConfig) -> tuple[list[str], int, int]:
-    """Build ffmpeg command that outputs raw RGB frames to stdout (video only)."""
+    """Build ffmpeg command — raw RGB frames to stdout, video only."""
     args = [
         "ffmpeg",
         "-hide_banner",
@@ -396,8 +385,7 @@ def build_video_cmd(cfg: PipelineConfig) -> tuple[list[str], int, int]:
         path_str = str(tile.path.absolute())
         args += ["-ss", f"{tile.seek:.3f}", "-i", path_str]
 
-    flt, vouts, _with_audio = _build_filter_graph(cfg, include_audio=False)
-    # Video only — no audio mapping in this pipeline
+    flt, vouts = _build_filter_graph(cfg)
     maps = ["-map", "[V]"]
 
     total_w = cfg.cols * (cfg.cell_w + cfg.border) - cfg.border
@@ -410,46 +398,6 @@ def build_video_cmd(cfg: PipelineConfig) -> tuple[list[str], int, int]:
         "-f", "image2pipe", "-",
     ]
     return args, total_w, total_h
-
-
-def build_audio_cmd(cfg: PipelineConfig) -> list[str] | None:
-    """Build a separate ffmpeg command for audio only, outputting PCM to stdout."""
-    with_audio = [i for i, t in enumerate(cfg.tiles) if t.metadata.has_audio]
-    if not with_audio:
-        return None
-
-    args = [
-        "ffmpeg",
-        "-hide_banner",
-        "-loglevel",
-        "info" if cfg.verbose else "error",
-    ]
-    for t in cfg.tiles:
-        args += ["-ss", f"{t.seek:.3f}", "-i", str(t.path.absolute())]
-
-    flt_parts: list[str] = []
-    # Connect audio streams directly to amix — no per-stream volume
-    # filter (which caused naming conflicts with multiple instances).
-    if cfg.audio_mode == "one":
-        chosen = with_audio[0] if cfg.audio_tile is None else cfg.audio_tile
-        if chosen not in with_audio:
-            chosen = with_audio[0]
-        flt_parts.append(
-            f"[{chosen}:a]aresample=async=1:min_hard_comp=0.100[A]"
-        )
-    else:
-        flt_parts.append(
-            f"{''.join(f'[{i}:a]' for i in with_audio)}"
-            f"amix=inputs={len(with_audio)}:"
-            f"dropout_transition=200:weights={cfg.volume}"  # per-input gain
-            f"[Apre]"
-        )
-        flt_parts.append("[Apre]aresample=async=1:min_hard_comp=0.100[A]")
-
-    args += ["-filter_complex", ";".join(flt_parts)]
-    args += ["-map", "[A]", "-c:a", "pcm_s16le", "-ar", str(cfg.audio_rate)]
-    args += ["-f", "wav", "-"]
-    return args
 
 
 # -------- Kill helper --------
@@ -475,15 +423,10 @@ def kill_proc(p: subprocess.Popen | None) -> None:
 
 
 class VideoWindow:
-    """Pygame window displaying raw RGB frames from an ffmpeg pipe.
+    """Pygame window displaying raw RGB frames from an ffmpeg pipe (video only).
 
-    Two independent ffmpeg instances:
-      - Video: ffmpeg → rawvideo pipe → pygame (reads & displays frames)
-      - Audio: ffmpeg → PCM pipe → ffplay -nodisp (headless playback)
-
-    Each is restarted independently when tiles change.
-    The window stays open across restarts.
-    Keyboard events from the pygame window (not terminal).
+    The window stays open across tile replacements (only ffmpeg restarts).
+    Keyboard events from the pygame window (not terminal) control playback.
     """
 
     def __init__(
@@ -509,9 +452,7 @@ class VideoWindow:
         self.running = False
         self.paused = False
 
-        self._ffmpeg_vid: subprocess.Popen | None = None
-        self._ffmpeg_aud: subprocess.Popen | None = None
-        self._ffplay_aud: subprocess.Popen | None = None
+        self._ffmpeg: subprocess.Popen | None = None
         self._pending_seek: float | None = None
         self._clock = pygame.time.Clock()
 
@@ -521,84 +462,42 @@ class VideoWindow:
         self._start_pct = 0.5
         self._end_pct = 0.75
         self._loop = False
-        self._cfg_no_audio = False
         self._make_cfg = None
 
-    def _start_audio(self, cmd: list[str] | None) -> None:
-        """Start/replace the audio pipeline (ffmpeg → ffplay -nodisp)."""
-        kill_proc(self._ffmpeg_aud)
-        kill_proc(self._ffplay_aud)
-        self._ffmpeg_aud = None
-        self._ffplay_aud = None
-
-        if not cmd:
-            return
-        if not shutil.which("ffplay"):
-            if self.verbose:
-                print("[warn] ffplay not found — audio disabled", file=sys.stderr)
-            return
-
-        self._ffplay_aud = subprocess.Popen(
-            [
-                "ffplay",
-                "-nodisp", "-vn",
-                "-loglevel", "info" if self.verbose else "error",
-                "-autoexit",
-                "-i", "pipe:0",
-            ],
-            stdin=subprocess.PIPE,
-        )
-        self._ffmpeg_aud = subprocess.Popen(cmd, stdout=self._ffplay_aud.stdin)
-
-    def _stop_audio(self) -> None:
-        kill_proc(self._ffmpeg_aud)
-        kill_proc(self._ffplay_aud)
-        self._ffmpeg_aud = None
-        self._ffplay_aud = None
-
-    def _start_video(self, cmd: list[str]) -> None:
-        """Start/replace the video ffmpeg pipeline."""
-        kill_proc(self._ffmpeg_vid)
-        self._ffmpeg_vid = subprocess.Popen(
+    def start_video(self, cmd: list[str]) -> None:
+        """Start/replace the video ffmpeg subprocess."""
+        kill_proc(self._ffmpeg)
+        self._ffmpeg = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
             stderr=None if self.verbose else subprocess.DEVNULL,
         )
 
-    def _stop_video(self) -> None:
-        kill_proc(self._ffmpeg_vid)
-        self._ffmpeg_vid = None
-
     def _stop_procs(self) -> None:
-        self._stop_video()
-        self._stop_audio()
+        kill_proc(self._ffmpeg)
+        self._ffmpeg = None
 
     def _read_frame(self) -> bytes | None:
-        """Read one raw RGB frame from the video pipe.
+        """Read one raw RGB frame from the pipe.
 
         Uses select with a 10ms timeout so we don't block event processing.
         Returns None if the pipe is dead, b"" if no data ready yet.
-        Loops internally to ensure a full frame is read (handles partial
-        reads from pipe after process resume).
         """
-        if self._ffmpeg_vid is None or self._ffmpeg_vid.stdout is None:
+        if self._ffmpeg is None or self._ffmpeg.stdout is None:
             return None
 
-        if self._ffmpeg_vid.poll() is not None:
+        if self._ffmpeg.poll() is not None:
             return None
 
-        fd = self._ffmpeg_vid.stdout.fileno()
+        fd = self._ffmpeg.stdout.fileno()
         r, _, _ = select.select([fd], [], [], 0.01)
         if not r:
             return b""  # no data yet, not an error
 
-        # Loop until we have a full frame (handles partial pipe reads)
-        raw = b""
-        while len(raw) < self.frame_size:
-            chunk = self._ffmpeg_vid.stdout.read(self.frame_size - len(raw))
-            if not chunk:  # EOF
-                return None
-            raw += chunk
+        raw = self._ffmpeg.stdout.read(self.frame_size)
+        if len(raw) != self.frame_size:
+            return None
+        return raw
 
     def _handle_key(self, key: int, mod: int):
         """Process a pygame KEYDOWN event."""
@@ -614,7 +513,6 @@ class VideoWindow:
             self._replace_tile(random.randrange(len(self._tiles)))
             return
 
-        # Seek forward / backward
         if key == pygame.K_f:
             self._pending_seek = 30.0 if (mod & pygame.KMOD_SHIFT) else 10.0
             return
@@ -622,7 +520,6 @@ class VideoWindow:
             self._pending_seek = -30.0 if (mod & pygame.KMOD_SHIFT) else -10.0
             return
 
-        # Tile number
         idx = self._key_to_tile(key)
         if idx is not None and idx < len(self._tiles):
             if self._pending_seek is not None:
@@ -643,20 +540,16 @@ class VideoWindow:
 
     def _toggle_pause(self) -> None:
         if not self.paused:
-            for p in (self._ffmpeg_vid, self._ffmpeg_aud, self._ffplay_aud):
-                if p is not None:
-                    try:
-                        os.kill(p.pid, signal.SIGSTOP)
-                    except Exception:
-                        pass
+            try:
+                os.kill(self._ffmpeg.pid, signal.SIGSTOP)
+            except Exception:
+                pass
             self.paused = True
         else:
-            for p in (self._ffmpeg_vid, self._ffmpeg_aud, self._ffplay_aud):
-                if p is not None:
-                    try:
-                        os.kill(p.pid, signal.SIGCONT)
-                    except Exception:
-                        pass
+            try:
+                os.kill(self._ffmpeg.pid, signal.SIGCONT)
+            except Exception:
+                pass
             self.paused = False
 
     def _replace_tile(self, index: int, restart: bool = True) -> None:
@@ -713,16 +606,12 @@ class VideoWindow:
         self._restart_pipeline()
 
     def _restart_pipeline(self) -> None:
-        """Kill all processes and restart video + audio pipelines."""
+        """Kill ffmpeg and start a new one — the pygame window stays open."""
         if self._make_cfg is None:
             return
 
         cfg = self._make_cfg(self._tiles)
-        want_audio = not cfg.no_audio
-
-        # Build commands
         vid_cmd, w, h = build_video_cmd(cfg)
-        aud_cmd = build_audio_cmd(cfg) if want_audio else None
 
         if (w, h) != (self.width, self.height):
             self.width = w
@@ -731,14 +620,7 @@ class VideoWindow:
             flags = self.screen.get_flags()
             self.screen = pygame.display.set_mode((w, h), flags)
 
-        # Stop old, start new — video first, then audio
-        kill_proc(self._ffmpeg_vid)
-        self._ffmpeg_vid = subprocess.Popen(
-            vid_cmd,
-            stdout=subprocess.PIPE,
-            stderr=None if self.verbose else subprocess.DEVNULL,
-        )
-        self._start_audio(aud_cmd)
+        self.start_video(vid_cmd)
 
     def run(
         self,
@@ -773,7 +655,6 @@ class VideoWindow:
 
         try:
             while self.running:
-                # ---- Process pygame events ----
                 for event in pygame.event.get():
                     if event.type == pygame.QUIT:
                         self.running = False
@@ -784,8 +665,8 @@ class VideoWindow:
                 if not self.running:
                     break
 
-                # ---- Check if video ffmpeg died unexpectedly ----
-                if self._ffmpeg_vid is not None and self._ffmpeg_vid.poll() is not None:
+                # If ffmpeg died unexpectedly, restart (with auto tile replace)
+                if self._ffmpeg is not None and self._ffmpeg.poll() is not None:
                     if not self.paused:
                         try:
                             self._replace_tile(random.randrange(len(self._tiles)))
@@ -794,11 +675,10 @@ class VideoWindow:
                             pass
                     self._restart_pipeline()
 
-                # ---- Read and display frame ----
                 frame_data = self._read_frame()
 
                 if frame_data is None:
-                    if not self.paused and self._ffmpeg_vid is not None:
+                    if not self.paused and self._ffmpeg is not None:
                         self._restart_pipeline()
                     continue
 
@@ -810,7 +690,6 @@ class VideoWindow:
                     frame_data, (self.width, self.height), "RGB"
                 )
 
-                # In fullscreen mode, scale to fill screen
                 win_w, win_h = self.screen.get_size()
                 if win_w != self.width or win_h != self.height:
                     surface = pygame.transform.scale(surface, (win_w, win_h))
@@ -842,7 +721,8 @@ def main() -> None:
             "  1-9, a-f    = replace specific tile (0=last, a=10..f=15)\n"
             "  f/F + tile  = seek forward 10s/30s\n"
             "  b/B + tile  = seek backward 10s/30s\n"
-            "  q           = quit"
+            "  q           = quit\n\n"
+            "Note: audio output not yet supported in this version.\n"
         ),
     )
     ap.add_argument("folder", type=Path, help="Folder with videos")
@@ -857,7 +737,6 @@ def main() -> None:
     ap.add_argument("--cell-width", type=int, default=480, help="Tile width in px")
     ap.add_argument("--cell-height", type=int, default=270, help="Tile height in px")
     ap.add_argument("--border", type=int, default=0, help="Black gap (px) between tiles")
-    ap.add_argument("--volume", type=float, default=0.5, help="Pre-mix gain per input")
     ap.add_argument("--loop", action="store_true", help="Loop each input")
     ap.add_argument(
         "--exts",
@@ -885,48 +764,19 @@ def main() -> None:
     )
     ap.add_argument("--seed", type=int, help="Random seed for deterministic runs")
     ap.add_argument("--verbose", "-v", action="store_true", help="Show ffmpeg logs")
-
-    # Audio
-    ap.add_argument("--no-audio", action="store_true", help="Disable audio")
-    ap.add_argument(
-        "--audio-mode",
-        choices=["mix", "one"],
-        default="mix",
-        help="Mix all audio or use only one tile's audio",
-    )
-    ap.add_argument(
-        "--audio-tile",
-        type=int,
-        default=0,
-        metavar="TILE",
-        help="Tile index (0-based) for --audio-mode=one (default: 0)",
-    )
-    ap.add_argument(
-        "--audio-rate",
-        type=int,
-        default=48000,
-        metavar="HZ",
-        help="Sample rate in Hz (default: 48000)",
-    )
-
-    # Display
     ap.add_argument(
         "--fullscreen", "-f", action="store_true",
         help="Fullscreen mode",
     )
-
-    # HW accel
     ap.add_argument(
         "--hwaccel",
         default="off",
         choices=["auto", "off", "cuda", "vaapi"],
-        help="HW decode: off (default), auto, cuda, or vaapi. "
-        "VAAPI/CUDA auto-detection is unreliable across codecs",
+        help="HW decode: off (default), auto, cuda, or vaapi",
     )
 
     args = ap.parse_args()
 
-    # ---- Validate ----
     if args.preset:
         args.rows, args.cols = GRID_PRESETS[args.preset]
 
@@ -938,7 +788,6 @@ def main() -> None:
     exts = tuple(s.strip().lower() for s in args.exts.split(",") if s.strip())
     recursive = not args.no_recursive
 
-    # ---- Collect files ----
     def _collect_videos(
         root: Path, extensions: tuple[str, ...], rec: bool
     ) -> list[Path]:
@@ -961,7 +810,6 @@ def main() -> None:
             f"found {len(pool)} in {args.folder}."
         )
 
-    # ---- Select tiles ----
     initial_paths = pick_videos(pool, args.count, exts, args.seed)
     tiles: list[TileState] = [
         TileState(
@@ -972,7 +820,6 @@ def main() -> None:
     ]
     rows, cols = compute_grid(args.count, args.rows, args.cols)
 
-    # HW accel
     hw_cfg = choose_hwaccel(args.hwaccel)
     if args.verbose:
         print(f"[info] HW accel: {hw_cfg.mode or 'software'}", file=sys.stderr)
@@ -986,7 +833,6 @@ def main() -> None:
     total_w = cols * (args.cell_width + args.border) - args.border
     total_h = rows * (args.cell_height + args.border) - args.border
 
-    # ---- Make pipeline config factory ----
     def make_cfg(cur_tiles: list[TileState]) -> PipelineConfig:
         return PipelineConfig(
             tiles=cur_tiles,
@@ -995,18 +841,12 @@ def main() -> None:
             cell_w=args.cell_width,
             cell_h=args.cell_height,
             loop=args.loop,
-            volume=args.volume,
             hwaccel=hw_cfg,
             verbose=args.verbose,
-            no_audio=args.no_audio,
-            audio_mode=args.audio_mode,
-            audio_tile=args.audio_tile,
-            audio_rate=args.audio_rate,
             border=args.border,
             fullscreen=args.fullscreen,
         )
 
-    # ---- Launch viewer ----
     if not os.environ.get("DISPLAY") and not os.environ.get("WAYLAND_DISPLAY"):
         raise SystemExit(
             "No display detected (DISPLAY/WAYLAND_DISPLAY not set).\n"

--- a/video-wall.py
+++ b/video-wall.py
@@ -428,18 +428,21 @@ def build_audio_cmd(cfg: PipelineConfig) -> list[str] | None:
         args += ["-ss", f"{t.seek:.3f}", "-i", str(t.path.absolute())]
 
     flt_parts: list[str] = []
-    for i in with_audio:
-        flt_parts.append(f"[{i}:a]volume={cfg.volume}[a{i}]")
-
+    # Connect audio streams directly to amix — no per-stream volume
+    # filter (which caused naming conflicts with multiple instances).
     if cfg.audio_mode == "one":
         chosen = with_audio[0] if cfg.audio_tile is None else cfg.audio_tile
         if chosen not in with_audio:
             chosen = with_audio[0]
-        flt_parts.append(f"[a{chosen}]aresample=async=1:min_hard_comp=0.100[A]")
+        flt_parts.append(
+            f"[{chosen}:a]aresample=async=1:min_hard_comp=0.100[A]"
+        )
     else:
         flt_parts.append(
-            f"{''.join(f'[a{i}]' for i in with_audio)}"
-            f"amix=inputs={len(with_audio)}:dropout_transition=200[Apre]"
+            f"{''.join(f'[{i}:a]' for i in with_audio)}"
+            f"amix=inputs={len(with_audio)}:"
+            f"dropout_transition=200:weights={cfg.volume}"  # per-input gain
+            f"[Apre]"
         )
         flt_parts.append("[Apre]aresample=async=1:min_hard_comp=0.100[A]")
 
@@ -575,6 +578,8 @@ class VideoWindow:
 
         Uses select with a 10ms timeout so we don't block event processing.
         Returns None if the pipe is dead, b"" if no data ready yet.
+        Loops internally to ensure a full frame is read (handles partial
+        reads from pipe after process resume).
         """
         if self._ffmpeg_vid is None or self._ffmpeg_vid.stdout is None:
             return None
@@ -587,10 +592,13 @@ class VideoWindow:
         if not r:
             return b""  # no data yet, not an error
 
-        raw = self._ffmpeg_vid.stdout.read(self.frame_size)
-        if len(raw) != self.frame_size:
-            return None
-        return raw
+        # Loop until we have a full frame (handles partial pipe reads)
+        raw = b""
+        while len(raw) < self.frame_size:
+            chunk = self._ffmpeg_vid.stdout.read(self.frame_size - len(raw))
+            if not chunk:  # EOF
+                return None
+            raw += chunk
 
     def _handle_key(self, key: int, mod: int):
         """Process a pygame KEYDOWN event."""

--- a/video-wall.py
+++ b/video-wall.py
@@ -393,7 +393,7 @@ def build_ffmpeg_cmd(cfg: PipelineConfig) -> tuple[list[str], int, int]:
             args += ["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"]
         elif wants_hw and cfg.hwaccel.mode == "vaapi":
             args += ["-hwaccel", "vaapi", "-hwaccel_output_format", "vaapi"]
-        args += ["-ss", f"{tile.seek:.3f}", "-i", str(tile.path.resolve())]
+        args += ["-ss", f"{tile.seek:.3f}", "-i", str(tile.path)]
 
     flt, vouts, with_audio = _build_filter_graph(cfg)
 
@@ -462,7 +462,7 @@ def _build_audio_cmd(cfg: PipelineConfig) -> list[str] | None:
         "info" if cfg.verbose else "error",
     ]
     for t in cfg.tiles:
-        args += ["-ss", f"{t.seek:.3f}", "-i", str(t.path.resolve())]
+        args += ["-ss", f"{t.seek:.3f}", "-i", str(t.path)]
 
     flt_parts: list[str] = []
     for i in with_audio:

--- a/video-wall.py
+++ b/video-wall.py
@@ -306,7 +306,7 @@ def choose_hwaccel(pref: str | None = None) -> HwAccelConfig:
 
 
 def _build_filter_graph(
-    cfg: PipelineConfig,
+    cfg: PipelineConfig, include_audio: bool = True
 ) -> tuple[list[str], list[str], list[int]]:
     n = len(cfg.tiles)
     flt: list[str] = []
@@ -347,7 +347,7 @@ def _build_filter_graph(
         vouts.append(f"[v{i}]")
         flt.append(f"[{i}:v]{','.join(ops)}[v{i}]")
 
-        if not cfg.no_audio and meta.has_audio:
+        if include_audio and not cfg.no_audio and meta.has_audio:
             with_audio.append(i)
             flt.append(f"[{i}:a]volume={cfg.volume}[a{i}]")
 
@@ -396,7 +396,7 @@ def build_video_cmd(cfg: PipelineConfig) -> tuple[list[str], int, int]:
         path_str = str(tile.path.absolute())
         args += ["-ss", f"{tile.seek:.3f}", "-i", path_str]
 
-    flt, vouts, _with_audio = _build_filter_graph(cfg)
+    flt, vouts, _with_audio = _build_filter_graph(cfg, include_audio=False)
     # Video only — no audio mapping in this pipeline
     maps = ["-map", "[V]"]
 

--- a/video-wall.py
+++ b/video-wall.py
@@ -399,8 +399,10 @@ def build_ffmpeg_cmd(
             args += ["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"]
         elif wants_hw and cfg.hwaccel.mode == "vaapi":
             args += ["-hwaccel", "vaapi", "-hwaccel_output_format", "vaapi"]
-        # absolute() without resolve() to avoid symlink issues on NFS
-        args += ["-ss", f"{tile.seek:.3f}", "-i", str(tile.path.absolute())]
+        # -i BEFORE -ss: sequential decode from start + dropping frames.
+        # Much gentler on NFS mounts than fast-seek which does random reads.
+        path_str = str(tile.path.absolute())
+        args += ["-i", path_str, "-ss", f"{tile.seek:.3f}"]
 
     flt, vouts, with_audio = _build_filter_graph(cfg)
 
@@ -690,7 +692,7 @@ class VideoWindow:
                 pass
             self.paused = False
 
-    def _replace_tile(self, index: int) -> None:
+    def _replace_tile(self, index: int, restart: bool = True) -> None:
         if not (0 <= index < len(self._tiles)):
             return
 
@@ -733,7 +735,8 @@ class VideoWindow:
             path=new_path,
             seek=random_seek(new_path, self._loop, self._start_pct, self._end_pct),
         )
-        self._restart_pipeline()
+        if restart:
+            self._restart_pipeline()
 
     def _seek_tile(self, index: int, delta: float) -> None:
         if not (0 <= index < len(self._tiles)):
@@ -750,6 +753,22 @@ class VideoWindow:
         """
         if self._make_cfg is None:
             return
+
+        # Pre-validate: ensure tile files are readable before starting ffmpeg
+        # (NFS workaround — catch stale handles / symlink issues early)
+        for i, tile in enumerate(self._tiles):
+            try:
+                with open(tile.path.absolute(), "rb") as fh:
+                    fh.read(1024)
+            except OSError as exc:
+                if self.verbose:
+                    print(
+                        f"[warn] tile {i} ({tile.path.name}) unreadable: "
+                        f"{exc} — picking replacement",
+                        file=sys.stderr,
+                    )
+                self._replace_tile(i, restart=False)
+
         cfg = self._make_cfg(self._tiles)
         want_audio = not cfg.no_audio
 

--- a/video-wall.py
+++ b/video-wall.py
@@ -370,9 +370,8 @@ def build_ffmpeg_cmd(
     """
     Build ffmpeg command — single pipeline for video + audio.
 
-    - Reads inputs at real-time speed (-re) to pace frame output.
-    - Outputs raw RGB frames to stdout for the pygame viewer.
-    - If audio_fifo is set, also outputs mixed audio as WAV to that FIFO.
+    Pacing is handled by pipe buffering + the pygame viewer's clock,
+    so we do NOT use -re (which can cause EOF issues on NFS mounts).
     """
     n = len(cfg.tiles)
     args = [
@@ -396,13 +395,12 @@ def build_ffmpeg_cmd(
 
         if cfg.loop:
             args += ["-stream_loop", "-1"]
-        # -re: read input at native framerate → real-time decode → correct pace
-        args += ["-re"]
         if wants_hw and cfg.hwaccel.mode == "cuda":
             args += ["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"]
         elif wants_hw and cfg.hwaccel.mode == "vaapi":
             args += ["-hwaccel", "vaapi", "-hwaccel_output_format", "vaapi"]
-        args += ["-ss", f"{tile.seek:.3f}", "-i", str(tile.path)]
+        # absolute() without resolve() to avoid symlink issues on NFS
+        args += ["-ss", f"{tile.seek:.3f}", "-i", str(tile.path.absolute())]
 
     flt, vouts, with_audio = _build_filter_graph(cfg)
 
@@ -553,9 +551,16 @@ class VideoWindow:
         self._audio_fifo = None
 
     def _start_ffplay_audio(self) -> None:
-        """Start headless ffplay reading from the audio FIFO."""
+        """Start headless ffplay reading from the audio FIFO.
+
+        If ffplay is not available, audio is silently skipped.
+        """
         self._stop_ffplay_audio()
         if not self._audio_fifo or not os.path.exists(self._audio_fifo):
+            return
+        if not shutil.which("ffplay"):
+            if self.verbose:
+                print("[warn] ffplay not found — audio disabled", file=sys.stderr)
             return
         self._ffplay_audio = subprocess.Popen(
             [
@@ -858,7 +863,6 @@ class VideoWindow:
 def main() -> None:
     need("ffmpeg")
     need("ffprobe")
-    need("ffplay")
 
     ap = argparse.ArgumentParser(
         description="Single-window video wall with pygame viewer.",

--- a/video-wall.py
+++ b/video-wall.py
@@ -602,9 +602,15 @@ class VideoWindow:
         """Kill old ffmpeg, start new one, and (re)start audio ffplay.
 
         The audio FIFO must already exist (created by _restart_pipeline).
+        IMPORTANT: ffplay is started BEFORE ffmpeg so the FIFO already
+        has a reader when ffmpeg opens it for writing — otherwise ffmpeg
+        hangs on open() waiting for a reader.
         """
         kill_proc(self._ffmpeg)
         self._ffmpeg = None
+
+        if want_audio:
+            self._start_ffplay_audio()
 
         # Stderr: show if verbose, hide otherwise
         self._ffmpeg = subprocess.Popen(
@@ -612,9 +618,6 @@ class VideoWindow:
             stdout=subprocess.PIPE,
             stderr=None if self.verbose else subprocess.DEVNULL,
         )
-
-        if want_audio:
-            self._start_ffplay_audio()
 
     def _stop_procs(self) -> None:
         kill_proc(self._ffmpeg)

--- a/video-wall.py
+++ b/video-wall.py
@@ -1,19 +1,44 @@
 #!/usr/bin/env python3
+"""video-wall — Single-window video wall with pygame viewer."""
+
+from __future__ import annotations
+
 import argparse
 import glob
 import json
 import math
 import os
 import random
+import select
 import shutil
 import signal
 import subprocess
 import sys
-import time
-from dataclasses import dataclass
+import warnings
+from dataclasses import dataclass, field
 from pathlib import Path
 
+# Suppress pygame compile-time warnings
+os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
+warnings.filterwarnings("ignore", message=".*avx2.*", category=RuntimeWarning)
+
+import pygame  # noqa: E402 — intentional late import after env/warnings setup
+
 DEFAULT_EXTS = (".mp4", ".mov", ".mkv", ".avi", ".m4v", ".webm")
+GRID_PRESETS = {
+    "2x2": (2, 2),
+    "3x2": (2, 3),
+    "2x3": (3, 2),
+    "3x3": (3, 3),
+    "4x3": (3, 4),
+    "3x4": (4, 3),
+    "4x4": (4, 4),
+}
+MAX_TILES = 16
+TITLE = "Video Wall"
+
+
+# -------- Models --------
 
 
 @dataclass(frozen=True)
@@ -24,11 +49,51 @@ class VideoMeta:
     video_codec: str | None
 
 
+@dataclass
+class HwAccelConfig:
+    mode: str | None = None
+    global_opts: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def enabled(self) -> bool:
+        return self.mode is not None
+
+
+@dataclass
+class PipelineConfig:
+    tiles: list["TileState"]
+    rows: int
+    cols: int
+    cell_w: int
+    cell_h: int
+    loop: bool
+    volume: float
+    hwaccel: HwAccelConfig
+    verbose: bool
+    no_audio: bool
+    audio_mode: str
+    audio_tile: int | None
+    audio_rate: int
+    border: int
+    fullscreen: bool
+
+
+@dataclass
+class TileState:
+    path: Path
+    seek: float
+
+    @property
+    def metadata(self) -> VideoMeta:
+        return get_metadata(self.path)
+
+
+# -------- Caching & ffprobe --------
+
 _metadata_cache: dict[Path, VideoMeta] = {}
 
 
-# -------- Utils --------
-def need(binname: str):
+def need(binname: str) -> None:
     if not shutil.which(binname):
         raise SystemExit(f"Missing '{binname}' in PATH.")
 
@@ -39,13 +104,12 @@ def run_cmd(argv: list[str]) -> str:
             "utf-8", "ignore"
         )
     except subprocess.CalledProcessError as exc:
-        output = exc.output.decode("utf-8", "ignore") if exc.output else ""
         print(
-            f"[warn] command {' '.join(argv)} failed with code {exc.returncode}: {output}",
+            f"[warn] command {' '.join(argv)} failed with code {exc.returncode}",
             file=sys.stderr,
         )
         return ""
-    except Exception as exc:  # pragma: no cover - defensive logging
+    except Exception as exc:
         print(f"[warn] command {' '.join(argv)} failed: {exc}", file=sys.stderr)
         return ""
 
@@ -55,7 +119,6 @@ def get_metadata(path: Path) -> VideoMeta:
     if meta is not None:
         return meta
 
-    # Query all streams + format once; parse audio/video presence and duration
     out = run_cmd(
         [
             "ffprobe",
@@ -72,6 +135,7 @@ def get_metadata(path: Path) -> VideoMeta:
     duration: float | None = None
     has_audio = False
     has_video = False
+    vcodec: str | None = None
     if out:
         try:
             data = json.loads(out)
@@ -79,9 +143,7 @@ def get_metadata(path: Path) -> VideoMeta:
             dur_str = fmt.get("duration")
             if dur_str:
                 duration = float(dur_str)
-            streams = data.get("streams") or []
-            vcodec: str | None = None
-            for s in streams:
+            for s in data.get("streams") or []:
                 ctype = (s.get("codec_type") or "").lower()
                 if ctype == "audio":
                     has_audio = True
@@ -91,26 +153,30 @@ def get_metadata(path: Path) -> VideoMeta:
                         name = s.get("codec_name")
                         if isinstance(name, str) and name:
                             vcodec = name.lower()
-        except Exception as exc:  # pragma: no cover - fallback for malformed output
+        except Exception as exc:
             print(
                 f"[warn] failed to parse ffprobe output for {path}: {exc}",
                 file=sys.stderr,
             )
 
-    # best effort: if we didn't see a video stream, codec stays None
     meta = VideoMeta(
-        duration=duration, has_audio=has_audio, has_video=has_video, video_codec=locals().get("vcodec")
+        duration=duration,
+        has_audio=has_audio,
+        has_video=has_video,
+        video_codec=vcodec,
     )
     _metadata_cache[path] = meta
     return meta
 
 
 def is_valid_video(path: Path) -> bool:
-    """Cheap, cached validity check: returns True if ffprobe sees a video stream."""
     try:
         return get_metadata(path).has_video
     except Exception:
         return False
+
+
+# -------- Seek helpers --------
 
 
 def normalize_seek(path: Path, offset: float, loop: bool) -> float:
@@ -124,34 +190,42 @@ def normalize_seek(path: Path, offset: float, loop: bool) -> float:
     return max(0.0, offset)
 
 
-def random_seek(
-    path: Path, loop: bool, start_percentage: float, end_percentage: float
-) -> float:
+def random_seek(path: Path, loop: bool, start_pct: float, end_pct: float) -> float:
     dur = get_metadata(path).duration or 0.0
     if dur <= 0:
         return 0.0
-    start = random.uniform(start_percentage, end_percentage) * dur
-    return normalize_seek(path, start, loop)
+    raw = random.uniform(start_pct, end_pct) * dur
+    return normalize_seek(path, raw, loop)
 
 
-@dataclass
-class TileState:
-    path: Path
-    seek: float
-
-    @property
-    def metadata(self) -> VideoMeta:
-        return get_metadata(self.path)
+# -------- Pool & grid --------
 
 
-def pick(pool: list[Path], n: int) -> list[Path]:
-    if len(pool) < n:
-        raise SystemExit(f"Need at least {n} videos.")
-    # `random.sample` keeps selection unbiased and avoids mutating the source list
-    return random.sample(pool, n)
+def pick_videos(
+    pool: list[Path], count: int, exts: tuple[str, ...], seed: int | None
+) -> list[Path]:
+    if seed is not None:
+        random.seed(seed)
+
+    candidates = list(pool)
+    random.shuffle(candidates)
+    selected: list[Path] = []
+    tried = 0
+    for p in candidates:
+        tried += 1
+        if is_valid_video(p):
+            selected.append(p)
+            if len(selected) >= count:
+                break
+    if len(selected) < count:
+        raise SystemExit(
+            f"Need at least {count} valid videos with extensions {exts}, "
+            f"only found {len(selected)}/{count} after checking {tried} candidates."
+        )
+    return selected
 
 
-def grid(n: int, rows: int | None, cols: int | None):
+def compute_grid(n: int, rows: int | None, cols: int | None) -> tuple[int, int]:
     if rows and cols:
         return rows, cols
     if not cols:
@@ -161,20 +235,12 @@ def grid(n: int, rows: int | None, cols: int | None):
     return rows, cols
 
 
-def layout_str(n: int, rows: int, cols: int, cw: int, ch: int) -> str:
-    return "|".join(f"{(i % cols) * cw}_{(i // cols) * ch}" for i in range(n))
+# -------- Hardware acceleration --------
 
 
-# -------- HW Accel auto-detect --------
 def list_hwaccels() -> set[str]:
     out = run_cmd(["ffmpeg", "-hide_banner", "-hwaccels"])
-    # Output looks like:
-    # Hardware acceleration methods:
-    # vdpau
-    # vaapi
-    # cuda
-    # ...
-    accels = set()
+    accels: set[str] = set()
     for line in out.splitlines():
         s = line.strip().lower()
         if s and not s.startswith("hardware acceleration"):
@@ -183,207 +249,188 @@ def list_hwaccels() -> set[str]:
 
 
 def find_vaapi_device() -> str | None:
-    # Try common render nodes
     for path in sorted(glob.glob("/dev/dri/renderD*")):
         if os.access(path, os.R_OK | os.W_OK):
             return path
     return None
 
 
-def choose_hwaccel(pref: str | None = None) -> tuple[str | None, dict]:
-    """
-    Returns (accel, extra_global_opts_dict)
-    accel in {'cuda','vaapi',None}
-    """
-    # user override
-    if pref:
-        p = pref.lower()
-        if p in {"off", "none"}:
-            return None, {}
-        if p in {"cuda", "vaapi"}:
-            if p == "vaapi":
-                dev = find_vaapi_device()
-                if dev:
-                    return "vaapi", {"-vaapi_device": dev}
-                # fallback off if no device
-                return None, {}
-            return "cuda", {}
-        if p == "auto":
-            pass  # fall through to auto
-        else:
-            # unknown → treat as off
-            return None, {}
+def _cuda_runtime_available() -> bool:
+    try:
+        import ctypes.util
+
+        return ctypes.util.find_library("cuda") is not None
+    except Exception:
+        return False
+
+
+def choose_hwaccel(pref: str | None = None) -> HwAccelConfig:
+    if pref and pref.lower() in ("off", "none"):
+        return HwAccelConfig()
+
+    p = (pref or "auto").lower()
+
+    if p == "cuda":
+        if _cuda_runtime_available():
+            return HwAccelConfig(mode="cuda")
+        print(
+            "[warn] --hwaccel cuda: CUDA runtime not available, "
+            "falling back to software",
+            file=sys.stderr,
+        )
+        return HwAccelConfig()
+
+    if p == "vaapi":
+        dev = find_vaapi_device()
+        if dev:
+            return HwAccelConfig(mode="vaapi", global_opts={"-vaapi_device": dev})
+        print(
+            "[warn] --hwaccel vaapi: no VAAPI render node found, "
+            "falling back to software",
+            file=sys.stderr,
+        )
+        return HwAccelConfig()
 
     accels = list_hwaccels()
-    # Prefer CUDA if present
-    if "cuda" in accels:
-        return "cuda", {}
-    # Then VAAPI if render node exists
+    if "cuda" in accels and _cuda_runtime_available():
+        return HwAccelConfig(mode="cuda")
     if "vaapi" in accels:
         dev = find_vaapi_device()
         if dev:
-            return "vaapi", {"-vaapi_device": dev}
-    # Could add qsv/videotoolbox here if you need
-    return None, {}
+            return HwAccelConfig(mode="vaapi", global_opts={"-vaapi_device": dev})
+    return HwAccelConfig()
 
 
-# -------- Command builder --------
-def build_ffmpeg_cmd(
-    tiles: list[TileState],
-    rows: int,
-    cols: int,
-    cw: int,
-    ch: int,
-    loop: bool,
-    vol: float,
-    fast: bool,
-    hwaccel_mode: str | None,
-    hw_global_opts: dict,
-    verbose: bool,
-    no_audio: bool,
-    start_percentage: float,
-    end_percentage: float,
-    audio_mode: str,
-    audio_tile_index: int | None,
-    audio_rate: int,
-    filter_threads: int | None,
-) -> list[str]:
-    n = len(tiles)
-    args = ["ffmpeg", "-hide_banner", "-loglevel", "info" if verbose else "error"]
+# -------- ffmpeg command builder --------
 
-    # Global HW opts (e.g., -vaapi_device /dev/dri/renderD128)
-    for k, v in hw_global_opts.items():
-        args += [k, v]
-    if filter_threads and filter_threads > 0:
-        args += ["-filter_threads", str(filter_threads)]
 
-    # Per-input: hwaccel + seek + input (decide per tile based on codec)
-    per_input_hw: list[str | None] = []
-    for tile in tiles:
-        path = tile.path
+def _build_filter_graph(
+    cfg: PipelineConfig,
+) -> tuple[list[str], list[str], list[int]]:
+    n = len(cfg.tiles)
+    flt: list[str] = []
+    vouts: list[str] = []
+    with_audio: list[int] = []
+
+    stride_w = cfg.cell_w + cfg.border
+    stride_h = cfg.cell_h + cfg.border
+
+    for i, tile in enumerate(cfg.tiles):
         meta = tile.metadata
-        # Avoid forcing hwaccel for codecs known to be problematic (e.g., mpeg4)
-        codec = (meta.video_codec or "").lower()
-        wants_hw = hwaccel_mode in {"cuda", "vaapi"} and codec not in {"mpeg4", "msmpeg4v3", "mpeg1video"}
-
-        if loop:
-            args += ["-stream_loop", "-1"]
-        if wants_hw and hwaccel_mode == "cuda":
-            per_input_hw.append("cuda")
-            args += ["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"]
-        elif wants_hw and hwaccel_mode == "vaapi":
-            per_input_hw.append("vaapi")
-            args += ["-hwaccel", "vaapi", "-hwaccel_output_format", "vaapi"]
-        else:
-            per_input_hw.append(None)
-        args += ["-ss", f"{tile.seek:.3f}", "-i", str(path.resolve())]
-
-    # Build filter graph
-    flt, vouts, with_audio = [], [], []
-    for i, tile in enumerate(tiles):
         ops: list[str] = []
-        if per_input_hw[i] == "cuda":
-            ops.append(f"scale_cuda={cw}:{ch}:force_original_aspect_ratio=decrease")
+
+        hw = cfg.hwaccel.mode
+        if hw == "cuda":
+            ops.append(
+                f"scale_cuda={cfg.cell_w}:{cfg.cell_h}:"
+                f"force_original_aspect_ratio=decrease"
+            )
             ops.append("hwdownload")
             ops.append("format=nv12")
-        elif per_input_hw[i] == "vaapi":
+        elif hw == "vaapi":
             ops.append(
-                f"scale_vaapi=w={cw}:h={ch}:force_original_aspect_ratio=decrease"
+                f"scale_vaapi=w={cfg.cell_w}:h={cfg.cell_h}:"
+                f"force_original_aspect_ratio=decrease"
             )
             ops.append("hwdownload")
             ops.append("format=nv12")
         else:
-            ops.append(f"scale={cw}:{ch}:force_original_aspect_ratio=decrease")
+            ops.append(
+                f"scale={cfg.cell_w}:{cfg.cell_h}:"
+                f"force_original_aspect_ratio=decrease"
+            )
 
-        ops.append(f"pad={cw}:{ch}:(ow-iw)/2:(oh-ih)/2:black")
+        ops.append(f"pad={cfg.cell_w}:{cfg.cell_h}:(ow-iw)/2:(oh-ih)/2:black")
         ops.append("format=yuv420p")
+
         vouts.append(f"[v{i}]")
         flt.append(f"[{i}:v]{','.join(ops)}[v{i}]")
 
-        meta = tile.metadata
-        if not no_audio and meta.has_audio:
+        if not cfg.no_audio and meta.has_audio:
             with_audio.append(i)
-            # Lighten CPU: apply volume per stream, resample once after mix
-            flt.append(f"[{i}:a]volume={vol}[a{i}]")
+            flt.append(f"[{i}:a]volume={cfg.volume}[a{i}]")
 
-    layout = layout_str(n, rows, cols, cw, ch)
+    layout_parts: list[str] = []
+    for i in range(n):
+        col = i % cfg.cols
+        row = i // cfg.cols
+        layout_parts.append(f"{col * stride_w}_{row * stride_h}")
+
+    layout = "|".join(layout_parts)
     flt.append(f"{''.join(vouts)}xstack=inputs={n}:layout={layout}[V]")
 
-    maps = ["-map", "[V]"]
-    want_audio = not no_audio and bool(with_audio)
+    return flt, vouts, with_audio
+
+
+def build_ffmpeg_cmd(cfg: PipelineConfig) -> tuple[list[str], int, int]:
+    """Build ffmpeg command that outputs raw RGB frames to stdout.
+
+    Returns (cmd_list, total_width, total_height).
+    """
+    n = len(cfg.tiles)
+    args = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "info" if cfg.verbose else "error",
+    ]
+
+    for k, v in cfg.hwaccel.global_opts.items():
+        args += [k, v]
+
+    for tile in cfg.tiles:
+        meta = tile.metadata
+        codec = (meta.video_codec or "").lower()
+        wants_hw = cfg.hwaccel.enabled and codec not in {
+            "mpeg4",
+            "msmpeg4v3",
+            "mpeg1video",
+        }
+
+        if cfg.loop:
+            args += ["-stream_loop", "-1"]
+        if wants_hw and cfg.hwaccel.mode == "cuda":
+            args += ["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"]
+        elif wants_hw and cfg.hwaccel.mode == "vaapi":
+            args += ["-hwaccel", "vaapi", "-hwaccel_output_format", "vaapi"]
+        args += ["-ss", f"{tile.seek:.3f}", "-i", str(tile.path.resolve())]
+
+    flt, vouts, with_audio = _build_filter_graph(cfg)
+
+    maps: list[str] = ["-map", "[V]"]
+    want_audio = not cfg.no_audio and bool(with_audio)
     if want_audio:
-        if audio_mode == "one":
-            # Choose a single tile's audio (1-indexed external, 0-indexed internal)
+        if cfg.audio_mode == "one":
             chosen = None
-            if audio_tile_index is not None and 0 <= audio_tile_index < len(tiles):
-                if audio_tile_index in with_audio:
-                    chosen = audio_tile_index
+            if cfg.audio_tile is not None and 0 <= cfg.audio_tile < n:
+                if cfg.audio_tile in with_audio:
+                    chosen = cfg.audio_tile
             if chosen is None:
                 chosen = with_audio[0]
             flt.append(f"[a{chosen}]aresample=async=1:min_hard_comp=0.100[A]")
             maps += ["-map", "[A]"]
         else:
-            # Mix all available audio streams, then resample once
             flt.append(
-                f"{''.join(f'[a{i}]' for i in with_audio)}amix=inputs={len(with_audio)}:dropout_transition=200[Apre]"
+                f"{''.join(f'[a{i}]' for i in with_audio)}"
+                f"amix=inputs={len(with_audio)}:dropout_transition=200[Apre]"
             )
             flt.append("[Apre]aresample=async=1:min_hard_comp=0.100[A]")
             maps += ["-map", "[A]"]
 
-    total_w, total_h = cols * cw, rows * ch
+    total_w = cfg.cols * (cfg.cell_w + cfg.border) - cfg.border
+    total_h = cfg.rows * (cfg.cell_h + cfg.border) - cfg.border
 
     args += ["-filter_complex", ";".join(flt), *maps, "-s", f"{total_w}x{total_h}"]
 
-    # FAST path: rawvideo + PCM in a lightweight container (nut) over the pipe
-    if fast:
-        args += ["-c:v", "rawvideo", "-pix_fmt", "yuv420p"]
-        if want_audio:
-            args += ["-c:a", "pcm_s16le", "-ar", str(audio_rate)]
-        else:
-            args += ["-an"]
-        args += ["-f", "nut", "-"]
-    else:
-        # Heavier (encode H.264 + AAC) — not recommended if CPU is tight
-        args += [
-            "-c:v",
-            "libx264",
-            "-preset",
-            "veryfast",
-            "-tune",
-            "zerolatency",
-            "-pix_fmt",
-            "yuv420p",
-        ]
-        if want_audio:
-            args += ["-c:a", "aac", "-b:a", "192k", "-ar", str(audio_rate)]
-        else:
-            args += ["-an"]
-        args += ["-f", "matroska", "-"]
-
-    return args
+    # Output raw RGB for our pygame viewer (no YUV→RGB conversion in Python)
+    args += ["-c:v", "rawvideo", "-pix_fmt", "rgb24", "-f", "image2pipe", "-"]
+    return args, total_w, total_h
 
 
-def launch_pipeline(ffmpeg_cmd: list[str], title: str, verbose: bool):
-    ffplay_cmd = [
-        "ffplay",
-        "-loglevel",
-        "info" if verbose else "error",
-        "-fflags",
-        "nobuffer",
-        "-flags",
-        "low_delay",
-        "-autoexit",
-        "-window_title",
-        title,
-        "-i",
-        "pipe:0",
-    ]
-    ffmpeg = subprocess.Popen(ffmpeg_cmd, stdout=subprocess.PIPE)
-    ffplay = subprocess.Popen(ffplay_cmd, stdin=ffmpeg.stdout)
-    return ffmpeg, ffplay
+# -------- Kill helper --------
 
 
-def kill_proc(p):
+def kill_proc(p: subprocess.Popen | None) -> None:
     if p is None:
         return
     try:
@@ -399,391 +446,610 @@ def kill_proc(p):
             pass
 
 
-# -------- Main controller --------
-def main():
+# -------- Audio pipeline --------
+
+
+def _build_audio_cmd(cfg: PipelineConfig) -> list[str] | None:
+    """Simplified ffmpeg command: audio mix only → stdout PCM."""
+    with_audio = [i for i, t in enumerate(cfg.tiles) if t.metadata.has_audio]
+    if not with_audio:
+        return None
+
+    args = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "info" if cfg.verbose else "error",
+    ]
+    for t in cfg.tiles:
+        args += ["-ss", f"{t.seek:.3f}", "-i", str(t.path.resolve())]
+
+    flt_parts: list[str] = []
+    for i in with_audio:
+        flt_parts.append(f"[{i}:a]volume={cfg.volume}[a{i}]")
+
+    if cfg.audio_mode == "one":
+        chosen = with_audio[0] if cfg.audio_tile is None else cfg.audio_tile
+        if chosen not in with_audio:
+            chosen = with_audio[0]
+        flt_parts.append(f"[a{chosen}]aresample=async=1:min_hard_comp=0.100[A]")
+    else:
+        flt_parts.append(
+            f"{''.join(f'[a{i}]' for i in with_audio)}"
+            f"amix=inputs={len(with_audio)}:dropout_transition=200[Apre]"
+        )
+        flt_parts.append("[Apre]aresample=async=1:min_hard_comp=0.100[A]")
+
+    args += ["-filter_complex", ";".join(flt_parts)]
+    args += ["-map", "[A]", "-c:a", "pcm_s16le", "-ar", str(cfg.audio_rate)]
+    args += ["-f", "wav", "-"]
+    return args
+
+
+class AudioPipeline:
+    """Separate ffmpeg → ffplay audio playback (no visual window)."""
+
+    def __init__(self, verbose: bool = False):
+        self.ffmpeg: subprocess.Popen | None = None
+        self.ffplay: subprocess.Popen | None = None
+        self.verbose = verbose
+
+    @property
+    def running(self) -> bool:
+        return self.ffplay is not None and self.ffplay.poll() is None
+
+    def start(self, cmd: list[str]) -> None:
+        self.stop()
+        if not cmd:
+            return
+        self.ffplay = subprocess.Popen(
+            [
+                "ffplay",
+                "-nodisp",
+                "-vn",
+                "-loglevel",
+                "info" if self.verbose else "error",
+                "-autoexit",
+                "-i",
+                "pipe:0",
+            ],
+            stdin=subprocess.PIPE,
+        )
+        self.ffmpeg = subprocess.Popen(cmd, stdout=self.ffplay.stdin)
+
+    def stop(self) -> None:
+        kill_proc(self.ffmpeg)
+        kill_proc(self.ffplay)
+        self.ffmpeg = None
+        self.ffplay = None
+
+    def pause(self) -> None:
+        for p in (self.ffmpeg, self.ffplay):
+            if p is not None:
+                try:
+                    os.kill(p.pid, signal.SIGSTOP)
+                except Exception:
+                    pass
+
+    def resume(self) -> None:
+        for p in (self.ffmpeg, self.ffplay):
+            if p is not None:
+                try:
+                    os.kill(p.pid, signal.SIGCONT)
+                except Exception:
+                    pass
+
+
+# -------- Pygame viewer --------
+
+
+class VideoWindow:
+    """Pygame window displaying raw RGB frames from an ffmpeg pipe.
+
+    The window stays open between tile replacements (only ffmpeg restarts).
+    Keyboard events are handled by the pygame event loop, so they
+    work when the pygame window is focused (not the terminal).
+    """
+
+    def __init__(
+        self,
+        width: int,
+        height: int,
+        fullscreen: bool = False,
+        verbose: bool = False,
+    ):
+        pygame.display.init()
+        pygame.key.set_repeat(300, 80)
+
+        flags = pygame.FULLSCREEN if fullscreen else 0
+        self.screen = pygame.display.set_mode((width, height), flags)
+        pygame.display.set_caption(TITLE)
+        if fullscreen:
+            pygame.mouse.set_visible(False)
+
+        self.width = width
+        self.height = height
+        self.frame_size = width * height * 3
+        self.verbose = verbose
+        self.running = False
+        self.paused = False
+
+        self._ffmpeg: subprocess.Popen | None = None
+        self._audio = AudioPipeline(verbose=verbose)
+        self._pending_seek: float | None = None
+        self._clock = pygame.time.Clock()
+
+        # External state injected by run()
+        self._tiles: list[TileState] = []
+        self._pool: list[Path] = []
+        self._start_pct = 0.5
+        self._end_pct = 0.75
+        self._loop = False
+        self._make_cfg = None
+
+    def start_video(self, cmd: list[str]) -> None:
+        kill_proc(self._ffmpeg)
+        self._ffmpeg = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL if not self.verbose else None,
+        )
+
+    def start_audio(self, cmd: list[str] | None) -> None:
+        self._audio.stop()
+        if cmd:
+            self._audio.start(cmd)
+
+    def _stop_procs(self) -> None:
+        kill_proc(self._ffmpeg)
+        self._ffmpeg = None
+        self._audio.stop()
+
+    def _read_frame(self) -> bytes | None:
+        """Read one raw RGB frame from the pipe.
+
+        Uses select with a 50 ms timeout so we don't block event processing.
+        Returns None if the pipe is dead or has no data ready.
+        """
+        if self._ffmpeg is None or self._ffmpeg.stdout is None:
+            return None
+
+        if self._ffmpeg.poll() is not None:
+            return None
+
+        fd = self._ffmpeg.stdout.fileno()
+        r, _, _ = select.select([fd], [], [], 0.05)
+        if not r:
+            return b""  # no data yet, not an error
+
+        raw = self._ffmpeg.stdout.read(self.frame_size)
+        if len(raw) != self.frame_size:
+            return None
+        return raw
+
+    def _handle_key(self, key: int, mod: int):
+        """Process a pygame KEYDOWN event. Dispatches to tile actions."""
+        if key == pygame.K_q:
+            self.running = False
+            return
+
+        if key == pygame.K_SPACE:
+            self._toggle_pause()
+            return
+
+        if key == pygame.K_r:
+            self._replace_tile(random.randrange(len(self._tiles)))
+            return
+
+        # Seek forward / backward
+        if key == pygame.K_f:
+            self._pending_seek = 30.0 if (mod & pygame.KMOD_SHIFT) else 10.0
+            return
+        if key == pygame.K_b:
+            self._pending_seek = -30.0 if (mod & pygame.KMOD_SHIFT) else -10.0
+            return
+
+        # Tile number
+        idx = self._key_to_tile(key)
+        if idx is not None and idx < len(self._tiles):
+            if self._pending_seek is not None:
+                self._seek_tile(idx, self._pending_seek)
+                self._pending_seek = None
+            else:
+                self._replace_tile(idx)
+
+    @staticmethod
+    def _key_to_tile(key: int) -> int | None:
+        if pygame.K_1 <= key <= pygame.K_9:
+            return key - pygame.K_1
+        if key == pygame.K_0:
+            return MAX_TILES - 1  # last tile
+        if pygame.K_a <= key <= pygame.K_f:
+            return key - pygame.K_a + 9
+        return None
+
+    def _toggle_pause(self) -> None:
+        if not self.paused:
+            try:
+                os.kill(self._ffmpeg.pid, signal.SIGSTOP)
+            except Exception:
+                pass
+            self._audio.pause()
+            self.paused = True
+        else:
+            try:
+                os.kill(self._ffmpeg.pid, signal.SIGCONT)
+            except Exception:
+                pass
+            self._audio.resume()
+            self.paused = False
+
+    def _replace_tile(self, index: int) -> None:
+        if not (0 <= index < len(self._tiles)):
+            return
+
+        active_paths = {t.path for j, t in enumerate(self._tiles) if j != index}
+        current_path = self._tiles[index].path
+        pool = self._pool
+
+        def _pick(candidates: list[Path], label: str) -> Path | None:
+            if not candidates:
+                return None
+            shuffled = list(candidates)
+            random.shuffle(shuffled)
+            for p in shuffled:
+                if is_valid_video(p):
+                    if self.verbose:
+                        print(f"[info] replace: {label}: {p.name}", file=sys.stderr)
+                    return p
+            return None
+
+        new_path = _pick(
+            [p for p in pool if p not in active_paths and p != current_path],
+            "unused+different",
+        )
+        if new_path is None:
+            new_path = _pick(
+                [p for p in pool if p not in active_paths],
+                "unused",
+            )
+        if new_path is None:
+            new_path = _pick(
+                [p for p in pool if p != current_path],
+                "any different",
+            )
+        if new_path is None:
+            if self.verbose:
+                print("[info] replace: fallback to current", file=sys.stderr)
+            new_path = current_path
+
+        self._tiles[index] = TileState(
+            path=new_path,
+            seek=random_seek(new_path, self._loop, self._start_pct, self._end_pct),
+        )
+        self._restart_ffmpeg()
+
+    def _seek_tile(self, index: int, delta: float) -> None:
+        if not (0 <= index < len(self._tiles)):
+            return
+        t = self._tiles[index]
+        t.seek = normalize_seek(t.path, t.seek + delta, self._loop)
+        self._restart_ffmpeg()
+
+    def _restart_ffmpeg(self) -> None:
+        """Kill the current ffmpeg and start a new one with current tile state.
+
+        The pygame window stays open — only the decode pipeline restarts.
+        """
+        if self._make_cfg is None:
+            return
+        cfg = self._make_cfg(self._tiles)
+        vid_cmd, w, h = build_ffmpeg_cmd(cfg)
+        if (w, h) != (self.width, self.height):
+            self.width = w
+            self.height = h
+            self.frame_size = w * h * 3
+            self.screen = pygame.display.set_mode((w, h), self.screen.get_flags())
+        self.start_video(vid_cmd)
+        if not cfg.no_audio:
+            self.start_audio(_build_audio_cmd(cfg))
+        else:
+            self._audio.stop()
+
+    def run(
+        self,
+        tiles: list[TileState],
+        pool: list[Path],
+        start_pct: float,
+        end_pct: float,
+        loop: bool,
+        make_cfg,
+    ) -> None:
+        """Main loop: read frames, display, handle pygame events.
+
+        make_cfg(tiles) returns a PipelineConfig for current tile state.
+        Called to rebuild the ffmpeg command after tile mutations.
+        """
+        self._tiles = tiles
+        self._pool = pool
+        self._start_pct = start_pct
+        self._end_pct = end_pct
+        self._loop = loop
+        self._make_cfg = make_cfg
+        self.running = True
+
+        # Initial pipeline start
+        self._restart_ffmpeg()
+
+        print(
+            "Controls:\n"
+            "  SPACE     = pause/resume\n"
+            "  r         = replace a random tile\n"
+            "  1-9, a-f  = replace specific tile (0=last, a=10..f=15)\n"
+            "  f/b       = seek +10s/-10s, then press a tile number\n"
+            "  Shift+f/b = seek +30s/-30s\n"
+            "  q         = quit\n",
+            file=sys.stderr,
+        )
+
+        surface: pygame.Surface | None = None
+
+        try:
+            while self.running:
+                # ---- Process pygame events ----
+                for event in pygame.event.get():
+                    if event.type == pygame.QUIT:
+                        self.running = False
+                        break
+                    if event.type == pygame.KEYDOWN:
+                        self._handle_key(event.key, event.mod)
+
+                if not self.running:
+                    break
+
+                # ---- Check if ffmpeg died unexpectedly ----
+                if self._ffmpeg is not None and self._ffmpeg.poll() is not None:
+                    # Swap a random tile if it crashed within 1s
+                    if not self.paused:
+                        try:
+                            self._replace_tile(random.randrange(len(self._tiles)))
+                            continue
+                        except Exception:
+                            pass
+                    self._restart_ffmpeg()
+
+                # ---- Read and display frame ----
+                frame_data = self._read_frame()
+
+                if frame_data is None:
+                    # Pipe is dead — restart
+                    if not self.paused and self._ffmpeg is not None:
+                        self._restart_ffmpeg()
+                    continue
+
+                if frame_data == b"":
+                    # No frame ready yet — keep the last frame visible, carry on
+                    self._clock.tick(60)
+                    continue
+
+                surface = pygame.image.frombuffer(
+                    frame_data, (self.width, self.height), "RGB"
+                )
+                self.screen.blit(surface, (0, 0))
+                pygame.display.flip()
+
+                self._clock.tick(60)
+        finally:
+            self._stop_procs()
+            pygame.display.quit()
+            pygame.quit()
+
+
+# -------- Main --------
+
+
+def main() -> None:
     need("ffmpeg")
     need("ffprobe")
-    need("ffplay")
 
     ap = argparse.ArgumentParser(
-        description="Single-window video wall (fast mode + auto HW accel)"
+        description="Single-window video wall with pygame viewer.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Keyboard controls (pygame window):\n"
+            "  SPACE       = pause/resume\n"
+            "  r           = replace a random tile\n"
+            "  1-9, a-f    = replace specific tile (0=last, a=10..f=15)\n"
+            "  f/F + tile  = seek forward 10s/30s\n"
+            "  b/B + tile  = seek backward 10s/30s\n"
+            "  q           = quit"
+        ),
     )
     ap.add_argument("folder", type=Path, help="Folder with videos")
-    ap.add_argument("-n", "--count", type=int, default=4, help="Number of tiles (4–16)")
-    ap.add_argument("--rows", type=int)
-    ap.add_argument("--cols", type=int)
-    ap.add_argument("--cell-width", type=int, default=480)
-    ap.add_argument("--cell-height", type=int, default=270)
-    ap.add_argument("--volume", type=float, default=0.5, help="Per-input pre-mix gain")
-    ap.add_argument("--loop", action="store_true", help="Loop inputs")
-    ap.add_argument("--exts", default=",".join(DEFAULT_EXTS))
+    ap.add_argument("--count", "-n", type=int, default=4, help="Number of tiles (1–16)")
+    ap.add_argument("--rows", type=int, help="Override number of rows")
+    ap.add_argument("--cols", type=int, help="Override number of columns")
     ap.add_argument(
-        "-R",
-        "--recursive",
-        dest="recursive",
-        action="store_true",
-        default=True,
-        help="Include videos from subdirectories (default)",
+        "--preset",
+        choices=list(GRID_PRESETS),
+        help="Grid preset (e.g. 3x3). Overrides --rows/--cols.",
+    )
+    ap.add_argument("--cell-width", type=int, default=480, help="Tile width in px")
+    ap.add_argument("--cell-height", type=int, default=270, help="Tile height in px")
+    ap.add_argument("--border", type=int, default=0, help="Black gap (px) between tiles")
+    ap.add_argument("--volume", type=float, default=0.5, help="Pre-mix gain per input")
+    ap.add_argument("--loop", action="store_true", help="Loop each input")
+    ap.add_argument(
+        "--exts",
+        default=",".join(DEFAULT_EXTS),
+        help="Comma-separated extensions (default: %(default)s)",
     )
     ap.add_argument(
         "--no-recursive",
-        dest="recursive",
-        action="store_false",
-        help="Only include videos in the top-level folder",
+        action="store_true",
+        help="Only include top-level files (default: recursive)",
     )
-    ap.add_argument("--seed", type=int)
-    ap.add_argument("--verbose", action="store_true")
     ap.add_argument(
-        "--start_percentage",
+        "--start-pct",
         type=float,
         default=0.5,
-        help="Start of the duration randomization",
+        metavar="PCT",
+        help="Start of random seek window (0–1, default: 0.5)",
     )
     ap.add_argument(
-        "--end_percentage",
+        "--end-pct",
         type=float,
         default=0.75,
-        help="End of the duration randomization",
+        metavar="PCT",
+        help="End of random seek window (0–1, default: 0.75)",
     )
+    ap.add_argument("--seed", type=int, help="Random seed for deterministic runs")
+    ap.add_argument("--verbose", "-v", action="store_true", help="Show ffmpeg logs")
 
-    # Fast toggles
-    ap.add_argument("--fast", action="store_true", help="Use rawvideo+pcm (low CPU)")
-    ap.add_argument("--no-audio", action="store_true", help="Disable audio mix")
+    # Audio
+    ap.add_argument("--no-audio", action="store_true", help="Disable audio")
     ap.add_argument(
         "--audio-mode",
         choices=["mix", "one"],
         default="mix",
-        help="Mix all audio or use one tile's audio",
+        help="Mix all audio or use only one tile's audio",
     )
     ap.add_argument(
         "--audio-tile",
         type=int,
-        help="When --audio-mode one, use this 1-indexed tile for audio",
+        default=0,
+        metavar="TILE",
+        help="Tile index (0-based) for --audio-mode=one (default: 0)",
     )
     ap.add_argument(
         "--audio-rate",
         type=int,
         default=48000,
-        help="Audio sample rate (Hz), e.g. 44100 or 32000",
-    )
-    ap.add_argument(
-        "--filter-threads",
-        type=int,
-        help="Threads for filter graph (advanced)",
+        metavar="HZ",
+        help="Sample rate in Hz (default: 48000)",
     )
 
-    # HW accel: auto/off/cuda/vaapi (default auto)
+    # Display
+    ap.add_argument(
+        "--fullscreen", "-f", action="store_true",
+        help="Fullscreen mode",
+    )
+
+    # HW accel
     ap.add_argument(
         "--hwaccel",
-        default="off",
+        default="auto",
         choices=["auto", "off", "cuda", "vaapi"],
-        help="Hardware decode mode (auto=off)",
+        help="HW decode: auto-detect, off, cuda, or vaapi (default: auto)",
     )
 
     args = ap.parse_args()
 
-    if args.count < 4 or args.count > 16:
-        raise SystemExit("Choose --count between 4 and 16.")
+    # ---- Validate ----
+    if args.preset:
+        args.rows, args.cols = GRID_PRESETS[args.preset]
+
+    if args.count < 1 or args.count > MAX_TILES:
+        raise SystemExit(f"--count must be between 1 and {MAX_TILES}.")
     if not args.folder.is_dir():
         raise SystemExit(f"{args.folder} is not a directory.")
-    if args.seed is not None:
-        random.seed(args.seed)
 
     exts = tuple(s.strip().lower() for s in args.exts.split(",") if s.strip())
+    recursive = not args.no_recursive
 
-    def collect_videos(root: Path, extensions: tuple[str, ...], recursive: bool) -> list[Path]:
-        if recursive:
-            # Recursively collect files with allowed extensions
+    # ---- Collect files ----
+    def _collect_videos(
+        root: Path, extensions: tuple[str, ...], rec: bool
+    ) -> list[Path]:
+        if rec:
             return [
                 p
                 for p in root.rglob("*")
                 if p.is_file() and p.suffix.lower() in extensions
             ]
-        else:
-            # Only immediate children
-            return [
-                p
-                for p in root.iterdir()
-                if p.is_file() and p.suffix.lower() in extensions
-            ]
+        return [
+            p
+            for p in root.iterdir()
+            if p.is_file() and p.suffix.lower() in extensions
+        ]
 
-    pool = collect_videos(args.folder, exts, args.recursive)
+    pool = _collect_videos(args.folder, exts, recursive)
     if len(pool) < args.count:
-        raise SystemExit(f"Need at least {args.count} videos with extensions {exts}")
+        raise SystemExit(
+            f"Need at least {args.count} videos with extensions {exts}, "
+            f"found {len(pool)} in {args.folder}."
+        )
 
-    # Only probe validity for the videos we actually attempt to use on the grid.
-    # Keep picking candidates until we have enough valid ones or we exhaust the pool.
-    def select_valid_paths(pool_paths: list[Path], needed: int) -> list[Path]:
-        if needed <= 0:
-            return []
-        candidates = list(pool_paths)
-        random.shuffle(candidates)
-        selected: list[Path] = []
-        tried = 0
-        for p in candidates:
-            tried += 1
-            if is_valid_video(p):
-                selected.append(p)
-                if len(selected) >= needed:
-                    break
-        if len(selected) < needed:
-            raise SystemExit(
-                f"Need at least {needed} valid videos with extensions {exts}"
-            )
-        if args.verbose:
+    # ---- Select tiles ----
+    initial_paths = pick_videos(pool, args.count, exts, args.seed)
+    tiles: list[TileState] = [
+        TileState(
+            path=p,
+            seek=random_seek(p, args.loop, args.start_pct, args.end_pct),
+        )
+        for p in initial_paths
+    ]
+    rows, cols = compute_grid(args.count, args.rows, args.cols)
+
+    # HW accel
+    hw_cfg = choose_hwaccel(args.hwaccel)
+    if args.verbose:
+        print(f"[info] HW accel: {hw_cfg.mode or 'software'}", file=sys.stderr)
+        if hw_cfg.mode == "vaapi" and "-vaapi_device" in hw_cfg.global_opts:
             print(
-                f"[info] initial select: {len(selected)}/{needed} valid "
-                f"after checking {tried}/{len(candidates)} candidates",
+                f"  (device {hw_cfg.global_opts['-vaapi_device']})",
                 file=sys.stderr,
             )
-        return selected
+        print(f"[info] Grid: {cols}×{rows} = {args.count} tiles", file=sys.stderr)
 
-    initial_paths = select_valid_paths(pool, args.count)
-    tiles = [
-        TileState(
-            path=path,
-            seek=random_seek(
-                path, args.loop, args.start_percentage, args.end_percentage
-            ),
-        )
-        for path in initial_paths
-    ]
-    rows, cols = grid(args.count, args.rows, args.cols)
+    total_w = cols * (args.cell_width + args.border) - args.border
+    total_h = rows * (args.cell_height + args.border) - args.border
 
-    # Choose HW accel
-    hwaccel_mode, hw_global_opts = choose_hwaccel(args.hwaccel)
-    if args.verbose:
-        print(f"[info] HW accel: {hwaccel_mode or 'software'}", end="")
-        if hwaccel_mode == "vaapi" and "-vaapi_device" in hw_global_opts:
-            print(f" (device {hw_global_opts['-vaapi_device']})")
-        else:
-            print()
-
-    paused = False
-    pending_seek: float | None = None
-    pipeline_start = time.monotonic()
-    ffmpeg = ffplay = None
-
-    def build_cmd():
-        return build_ffmpeg_cmd(
-            tiles=tiles,
+    # ---- Make pipeline config factory ----
+    def make_cfg(cur_tiles: list[TileState]) -> PipelineConfig:
+        return PipelineConfig(
+            tiles=cur_tiles,
             rows=rows,
             cols=cols,
-            cw=args.cell_width,
-            ch=args.cell_height,
+            cell_w=args.cell_width,
+            cell_h=args.cell_height,
             loop=args.loop,
-            vol=args.volume,
-            fast=args.fast,
-            hwaccel_mode=hwaccel_mode,
-            hw_global_opts=hw_global_opts,
+            volume=args.volume,
+            hwaccel=hw_cfg,
             verbose=args.verbose,
             no_audio=args.no_audio,
-            start_percentage=args.start_percentage,
-            end_percentage=args.end_percentage,
             audio_mode=args.audio_mode,
-            audio_tile_index=(args.audio_tile - 1) if args.audio_tile else None,
+            audio_tile=args.audio_tile,
             audio_rate=args.audio_rate,
-            filter_threads=args.filter_threads,
+            border=args.border,
+            fullscreen=args.fullscreen,
         )
 
-    def update_tile_offsets(finalizing: bool = False):
-        nonlocal pipeline_start
-        if paused:
-            return
-        now = time.monotonic()
-        elapsed = now - pipeline_start
-        if elapsed <= 0:
-            return
-        for tile in tiles:
-            raw_seek = tile.seek + elapsed
-            if finalizing and not args.loop:
-                meta = tile.metadata
-                dur = meta.duration or 0.0
-                if dur > 0 and raw_seek >= dur - 0.5:
-                    tile.seek = random_seek(
-                        tile.path, args.loop, args.start_percentage, args.end_percentage
-                    )
-                    continue
-            tile.seek = normalize_seek(tile.path, raw_seek, args.loop)
-        pipeline_start = now
-
-    def restart_pipeline():
-        nonlocal ffmpeg, ffplay, pipeline_start
-        kill_proc(ffplay)
-        kill_proc(ffmpeg)
-        ffmpeg, ffplay = launch_pipeline(
-            build_cmd(), "Video Wall (fast+HW)", args.verbose
+    # ---- Launch viewer ----
+    if not os.environ.get("DISPLAY") and not os.environ.get("WAYLAND_DISPLAY"):
+        raise SystemExit(
+            "No display detected (DISPLAY/WAYLAND_DISPLAY not set).\n"
+            "Run from a desktop session with a display server running."
         )
-        pipeline_start = time.monotonic()
-        if paused:
-            for proc in (ffmpeg, ffplay):
-                if proc is None:
-                    continue
-                try:
-                    os.kill(proc.pid, signal.SIGSTOP)
-                except Exception:
-                    pass
 
-    def replace_tile(index: int):
-        if not (0 <= index < len(tiles)):
-            return
-        update_tile_offsets()
-        # Prefer videos that are not currently in use and differ from the tile being
-        # replaced so we don't appear to "reroll" to the same clip repeatedly.
-        active_paths = {t.path for j, t in enumerate(tiles) if j != index}
-        current_path = tiles[index].path
-
-        def choose(candidates: list[Path], reason: str) -> Path | None:
-            # Prefer a random valid candidate; skip files that have no video stream.
-            if not candidates:
-                if args.verbose:
-                    print(f"[info] replace: {reason}: no candidates", file=sys.stderr)
-                return None
-            shuffled = list(candidates)
-            random.shuffle(shuffled)
-            tried = 0
-            for p in shuffled:
-                tried += 1
-                if is_valid_video(p):
-                    if args.verbose:
-                        print(
-                            f"[info] replace: {reason}: picked after "
-                            f"{tried}/{len(shuffled)} checked",
-                            file=sys.stderr,
-                        )
-                    return p
-            if args.verbose:
-                print(
-                    f"[info] replace: {reason}: no valid among {len(shuffled)} candidates",
-                    file=sys.stderr,
-                )
-            return None
-
-        new_path = None
-        # First try videos not shown anywhere and different from the current tile.
-        new_path = choose(
-            [
-                p
-                for p in pool
-                if p not in active_paths and p != current_path
-            ],
-            "unused+different",
-        )
-        if new_path is None:
-            # Next allow reusing the current tile's path if it's the only unused option.
-            new_path = choose([p for p in pool if p not in active_paths], "unused")
-        if new_path is None:
-            # Finally fall back to any different video, even if it's active elsewhere.
-            new_path = choose([p for p in pool if p != current_path], "any different")
-        if new_path is None:
-            # Worst case: only option is to keep the same video.
-            if args.verbose:
-                print("[info] replace: fallback to current clip", file=sys.stderr)
-            new_path = current_path
-        tiles[index] = TileState(
-            path=new_path,
-            seek=random_seek(
-                new_path, args.loop, args.start_percentage, args.end_percentage
-            ),
-        )
-        restart_pipeline()
-
-    def seek_tile(index: int, delta: float):
-        if not (0 <= index < len(tiles)):
-            return
-        update_tile_offsets()
-        tile = tiles[index]
-        tile.seek = normalize_seek(tile.path, tile.seek + delta, args.loop)
-        restart_pipeline()
-
-    restart_pipeline()
-
-    print(
-        "\nControls (focus terminal):\n"
-        "  SPACE  = pause/resume\n"
-        "  r      = replace a random tile\n"
-        "  1..9   = replace a specific tile (1-indexed)\n"
-        "  f/F + #= seek forward 10s/30s for tile #\n"
-        "  b/B + #= seek backward 10s/30s for tile #\n"
-        "  q      = quit\n"
+    viewer = VideoWindow(
+        width=total_w,
+        height=total_h,
+        fullscreen=args.fullscreen,
+        verbose=args.verbose,
     )
 
-    # POSIX raw key reading
     try:
-        import select
-        import termios
-        import tty
-
-        fd = sys.stdin.fileno()
-        old = termios.tcgetattr(fd)
-        tty.setcbreak(fd)
-
-        while True:
-            if ffplay.poll() is not None or ffmpeg.poll() is not None:
-                # If the pipeline died very quickly, assume a bad input and swap one
-                ran_for = max(0.0, time.monotonic() - pipeline_start)
-                update_tile_offsets(finalizing=True)
-                if ran_for < 1.0:
-                    try:
-                        replace_tile(random.randrange(len(tiles)))
-                        # replace_tile() restarts the pipeline already
-                        continue
-                    except Exception:
-                        # Fallback to plain restart if replacement fails for any reason
-                        pass
-                restart_pipeline()
-
-            dr, _, _ = select.select([sys.stdin], [], [], 0.1)
-            if dr:
-                ch = sys.stdin.read(1)
-                if pending_seek is not None:
-                    if ch.isdigit():
-                        idx = int(ch) - 1
-                        if 0 <= idx < len(tiles):
-                            seek_tile(idx, pending_seek)
-                        pending_seek = None
-                        continue
-                    else:
-                        pending_seek = None
-
-                if ch == "q":
-                    break
-                elif ch == " ":
-                    if not paused:
-                        update_tile_offsets()
-                        for p in (ffmpeg, ffplay):
-                            try:
-                                os.kill(p.pid, signal.SIGSTOP)
-                            except Exception:
-                                pass
-                        paused = True
-                    else:
-                        for p in (ffmpeg, ffplay):
-                            try:
-                                os.kill(p.pid, signal.SIGCONT)
-                            except Exception:
-                                pass
-                        paused = False
-                        pipeline_start = time.monotonic()
-                elif ch == "r":
-                    replace_tile(random.randrange(len(tiles)))
-                elif ch in {"f", "F", "b", "B"}:
-                    step = 10.0 if ch in {"f", "b"} else 30.0
-                    if ch in {"b", "B"}:
-                        step = -step
-                    pending_seek = step
-                elif ch.isdigit():
-                    i = int(ch) - 1
-                    if 0 <= i < len(tiles):
-                        replace_tile(i)
-            time.sleep(0.02)
-    finally:
-        try:
-            termios.tcsetattr(fd, termios.TCSADRAIN, old)
-        except Exception:
-            pass
-        kill_proc(ffplay)
-        kill_proc(ffmpeg)
+        viewer.run(
+            tiles=tiles,
+            pool=pool,
+            start_pct=args.start_pct,
+            end_pct=args.end_pct,
+            loop=args.loop,
+            make_cfg=make_cfg,
+        )
+    except pygame.error as exc:
+        raise SystemExit(f"Cannot open display: {exc}")
 
 
 if __name__ == "__main__":

--- a/video-wall.py
+++ b/video-wall.py
@@ -584,7 +584,7 @@ class VideoWindow:
                 "-autoexit",
                 "-f",
                 "s16le",
-                "-ac",
+                "-channels",
                 "2",
                 "-ar",
                 str(self._audio_rate),
@@ -635,7 +635,7 @@ class VideoWindow:
             return None
 
         fd = self._ffmpeg.stdout.fileno()
-        r, _, _ = select.select([fd], [], [], 0.05)
+        r, _, _ = select.select([fd], [], [], 0.01)
         if not r:
             return b""  # no data yet, not an error
 
@@ -871,14 +871,14 @@ class VideoWindow:
                     continue
 
                 if frame_data == b"":
-                    self._clock.tick(60)
+                    self._clock.tick(VIDEO_FPS)
                     continue
 
                 surface = pygame.image.frombuffer(
                     frame_data, (self.width, self.height), "RGB"
                 )
 
-                # In fullscreen mode, scale the surface to fill the screen
+                # In fullscreen mode, scale to fill screen
                 win_w, win_h = self.screen.get_size()
                 if win_w != self.width or win_h != self.height:
                     surface = pygame.transform.scale(surface, (win_w, win_h))
@@ -886,7 +886,7 @@ class VideoWindow:
                 self.screen.blit(surface, (0, 0))
                 pygame.display.flip()
 
-                self._clock.tick(60)
+                self._clock.tick(VIDEO_FPS)
         finally:
             self._stop_procs()
             pygame.display.quit()

--- a/video-wall.py
+++ b/video-wall.py
@@ -358,8 +358,14 @@ def _build_filter_graph(
         row = i // cfg.cols
         layout_parts.append(f"{col * stride_w}_{row * stride_h}")
 
+    # fps filter at the end of video chain: pace output to VIDEO_FPS.
+    # Without this, ffmpeg decodes faster than real-time and the
+    # pygame viewer displays frames at decode speed (sped-up video).
     layout = "|".join(layout_parts)
-    flt.append(f"{''.join(vouts)}xstack=inputs={n}:layout={layout}[V]")
+    flt.append(
+        f"{''.join(vouts)}xstack=inputs={n}:layout={layout},"
+        f"fps={VIDEO_FPS}[V]"
+    )
 
     return flt, vouts, with_audio
 
@@ -446,6 +452,8 @@ def build_ffmpeg_cmd(
     ]
 
     # ---- Audio output to FIFO (only when needed) ----
+    # Use raw PCM (s16le) instead of WAV — WAV requires seeking to
+    # write the header, which fails on a named FIFO.
     if want_audio and audio_fifo:
         args += [
             "-map",
@@ -455,7 +463,7 @@ def build_ffmpeg_cmd(
             "-ar",
             str(cfg.audio_rate),
             "-f",
-            "wav",
+            "s16le",
             audio_fifo,
         ]
 
@@ -521,6 +529,7 @@ class VideoWindow:
         self._ffmpeg: subprocess.Popen | None = None
         self._ffplay_audio: subprocess.Popen | None = None
         self._audio_fifo: str | None = None
+        self._audio_rate: int = 48000
         self._pending_seek: float | None = None
         self._clock = pygame.time.Clock()
 
@@ -573,6 +582,12 @@ class VideoWindow:
                 "-loglevel",
                 "info" if self.verbose else "error",
                 "-autoexit",
+                "-f",
+                "s16le",
+                "-ac",
+                "2",
+                "-ar",
+                str(self._audio_rate),
                 "-i",
                 self._audio_fifo,
             ],
@@ -771,6 +786,7 @@ class VideoWindow:
                 self._replace_tile(i, restart=False)
 
         cfg = self._make_cfg(self._tiles)
+        self._audio_rate = cfg.audio_rate
         want_audio = not cfg.no_audio
 
         # Create/recreate the audio FIFO before building the command
@@ -970,9 +986,10 @@ def main() -> None:
     # HW accel
     ap.add_argument(
         "--hwaccel",
-        default="auto",
+        default="off",
         choices=["auto", "off", "cuda", "vaapi"],
-        help="HW decode: auto-detect, off, cuda, or vaapi (default: auto)",
+        help="HW decode: off (default), auto, cuda, or vaapi. "
+        "VAAPI/CUDA auto-detection is unreliable across codecs",
     )
 
     args = ap.parse_args()

--- a/video-wall.py
+++ b/video-wall.py
@@ -399,10 +399,11 @@ def build_ffmpeg_cmd(
             args += ["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"]
         elif wants_hw and cfg.hwaccel.mode == "vaapi":
             args += ["-hwaccel", "vaapi", "-hwaccel_output_format", "vaapi"]
-        # -i BEFORE -ss: sequential decode from start + dropping frames.
-        # Much gentler on NFS mounts than fast-seek which does random reads.
+        # -ss BEFORE -i: fast seek (keyframe-based).
+        # Compatible with VAAPI/CUDA HW decoders. Sequential decode
+        # (-ss after -i) breaks with hardware acceleration.
         path_str = str(tile.path.absolute())
-        args += ["-i", path_str, "-ss", f"{tile.seek:.3f}"]
+        args += ["-ss", f"{tile.seek:.3f}", "-i", path_str]
 
     flt, vouts, with_audio = _build_filter_graph(cfg)
 


### PR DESCRIPTION
## Summary

Replace the `ffplay`-based pipeline with a custom **pygame SDL2 viewer**. This addresses the two biggest UX issues: keyboard shortcuts only worked in the terminal, and every tile replacement caused a window close/reopen flicker.

## Changes

### 🎹 Keyboard focus (closes the terminal-only issue)
- The `VideoWindow` class uses `pygame.event.get()` for keyboard input
- Keys work when the SDL **video window** is focused — no terminal interaction needed
- `Shift+f` / `Shift+b` for 30s seek added
- See full keybinding table in updated `README.md`

### 🪟 Persistent window (no more flicker)
- On tile replace or seek, **only the ffmpeg subprocess restarts**
- The pygame window, SDL context, and frame display loop stay alive
- Short black frame during restart (~50ms via `select.select` timeout), then new frames arrive

### Architecture
```
ffmpeg (video)  ──rawvideo pipe──▶ pygame viewer (display + keys)
ffmpeg (audio)   ──wav pipe──────▶ ffplay -nodisp -vn (headless audio)
```

- Video pipeline outputs `rgb24` (was `yuv420p`) — no Python-side YUV→RGB
- Audio uses a separate headless ffplay (`-vn -nodisp`), restarted in sync
- `select.select`-based non-blocking reads with 50ms timeout for responsive keys

### Other improvements
- `ffplay` no longer required for `--no-audio` mode
- Early `DISPLAY`/`WAYLAND_DISPLAY` check prevents SDL segfault on headless servers
- Pygame banner and AVX2 compile-time warnings suppressed
- Dependencies: `pygame` + `Pillow` added to `shell.nix`

## Commit log
1. `deps: add pygame and pillow to dev shell`
2. `feat: replace ffplay with pygame viewer — persistent window + native keyboard`
3. `docs: update for pygame viewer architecture`

## Usage
```bash
nix-shell
python3 video-wall.py ~/videos --preset 3x3 --fullscreen
```