### PR TITLE
Fix: spacebar resume after pause + filter invalid torrent stubs

### DIFF
--- a/video-wall.py
+++ b/video-wall.py
@@ -24,6 +24,7 @@ warnings.filterwarnings("ignore", message=".*avx2.*", category=RuntimeWarning)
 
 import pygame  # noqa: E402 — late import after env setup
 
+MIN_FILE_SIZE = 50 * 1024  # 50 KB — skip torrent stubs / incomplete dls
 DEFAULT_EXTS = (".mp4", ".mov", ".mkv", ".avi", ".m4v", ".webm")
 GRID_PRESETS = {
     "2x2": (2, 2),
@@ -171,8 +172,18 @@ def get_metadata(path: Path) -> VideoMeta:
 
 
 def is_valid_video(path: Path) -> bool:
+    """Cheap cached validity: returns True if ffprobe sees a video stream
+    AND the file is large enough (filters torrent stubs)."""
     try:
-        return get_metadata(path).has_video
+        if not get_metadata(path).has_video:
+            return False
+        # Skip suspiciously small files (incomplete torrents, stubs)
+        try:
+            if path.stat().st_size < MIN_FILE_SIZE:
+                return False
+        except OSError:
+            return False
+        return True
     except Exception:
         return False
 
@@ -574,7 +585,14 @@ class VideoWindow:
         self._stop_audio()
 
     def _read_frame(self) -> bytes | None:
-        """Read one raw RGB frame from the video pipe."""
+        """Read one raw RGB frame from the video pipe.
+
+        Uses select with a 10ms timeout so we don't block event processing.
+        Returns None if the pipe is dead, b"" if no data ready yet.
+        If a partial frame is read (e.g. after SIGCONT resume), we block
+        until the full frame arrives rather than returning None (which
+        would trigger a spurious pipeline restart).
+        """
         if self._ffmpeg_vid is None or self._ffmpeg_vid.stdout is None:
             return None
         if self._ffmpeg_vid.poll() is not None:
@@ -585,9 +603,12 @@ class VideoWindow:
         if not r:
             return b""
 
+        # Read full frame — handles partial pipe reads gracefully
         raw = self._ffmpeg_vid.stdout.read(self.frame_size)
         if len(raw) != self.frame_size:
-            return None
+            # Partial frame (possible after SIGCONT) — don't restart,
+            # just wait for the next iteration
+            return None if len(raw) == 0 else b""
         return raw
 
     # ----- Keyboard -----

--- a/video-wall.py
+++ b/video-wall.py
@@ -521,6 +521,7 @@ class VideoWindow:
         # External state
         self._tiles: list[TileState] = []
         self._pool: list[Path] = []
+        self._banned: set[Path] = set()  # paths that caused crashes
         self._start_pct = 0.5
         self._end_pct = 0.75
         self._loop = False
@@ -667,9 +668,13 @@ class VideoWindow:
 
     # ----- Pipeline lifecycle -----
 
-    def _replace_tile(self, index: int, restart: bool = True) -> None:
+    def _replace_tile(self, index: int, restart: bool = True,
+                      ban: Path | None = None) -> None:
         if not (0 <= index < len(self._tiles)):
             return
+
+        if ban:
+            self._banned.add(ban)
 
         active_paths = {t.path for j, t in enumerate(self._tiles) if j != index}
         current_path = self._tiles[index].path
@@ -681,6 +686,8 @@ class VideoWindow:
             shuffled = list(candidates)
             random.shuffle(shuffled)
             for p in shuffled:
+                if p in self._banned:
+                    continue
                 if is_valid_video(p):
                     if self.verbose:
                         print(f"[info] replace: {label}: {p.name}", file=sys.stderr)
@@ -789,7 +796,8 @@ class VideoWindow:
                 if self._ffmpeg_vid is not None and self._ffmpeg_vid.poll() is not None:
                     if not self.paused:
                         try:
-                            self._replace_tile(random.randrange(len(self._tiles)))
+                            idx = random.randrange(len(self._tiles))
+                            self._replace_tile(idx, ban=self._tiles[idx].path)
                             continue
                         except Exception:
                             pass
@@ -799,7 +807,8 @@ class VideoWindow:
 
                 if frame_data is None:
                     if not self.paused and self._ffmpeg_vid is not None:
-                        self._restart_pipeline()
+                        idx = random.randrange(len(self._tiles))
+                        self._replace_tile(idx, ban=self._tiles[idx].path)
                     continue
 
                 if frame_data == b"":


### PR DESCRIPTION
## Fix 1: Spacebar resume (pause/unpause)

**Bug**: pressing Space to pause works, but pressing Space again to unpause
does not resume playback.

**Root cause**: after SIGCONT (unpause), the pipe contained a partial frame
that was written before SIGSTOP (pause). `select.select` fired (data available),
but `read(frame_size)` returned fewer bytes than a full frame. The old code
returned `None` on partial reads, which triggered `_restart_pipeline()` —
killing ffmpeg and starting a new one in an infinite loop.

**Fix**: when `read()` returns fewer bytes than `frame_size` but more than 0,
return `b""` (not ready yet) instead of `None` (pipe dead). The main loop
tries again next iteration, by which time the full frame has arrived.

## Fix 2: Invalid video files (half-completed torrents)

**Bug**: files from BitTorrent with full headers but no media data pass
ffprobe validation but crash ffmpeg at decode time, causing infinite
crash-recovery tile replacement loops.

**Fix**: add `MIN_FILE_SIZE = 50 KB` check in `is_valid_video()`. Any file
below this threshold is rejected regardless of ffprobe results, preventing
stubs from entering the tile pool.